### PR TITLE
HNC quantum pseudopotentials

### DIFF
--- a/doc/examples/ionic/plot_HNC_ThreePotential_Wuensch.py
+++ b/doc/examples/ionic/plot_HNC_ThreePotential_Wuensch.py
@@ -1,0 +1,185 @@
+"""
+Static structure factor of the electron-ion system
+==================================================
+
+This shows the calculation of pair-distribution functions and static structure
+factors of a relatively cold electron-ion system, as suggested by
+:cite:`Wunsch.2008`. See fig. 3. of this publication. The work presented shows
+to usage of quantum pseudopotentials for the electron-ion and electron-electron
+interaction.
+"""
+
+import jax.numpy as jnp
+import jaxrts
+import jpu
+
+import matplotlib.pyplot as plt
+import scienceplots  # noqa: F401
+
+plt.style.use("science")
+
+ureg = jaxrts.ureg
+
+state = jaxrts.PlasmaState(
+    ions=[jaxrts.Element("H")],
+    Z_free=[1],
+    mass_density=[1e22] / (1 * ureg.centimeter**3) * ureg.proton_mass,
+    T_e=4.5e4 * ureg.kelvin,
+)
+
+pot = 16
+r = jpu.numpy.linspace(1e-1 * ureg.a0, 5e3 * ureg.a0, 2**pot)
+
+d = jpu.numpy.cbrt(
+    3 / (4 * jnp.pi * (state.n_i[:, jnp.newaxis] + state.n_i[jnp.newaxis, :]))
+)
+
+dr = r[1] - r[0]
+dk = jnp.pi / (len(r) * dr)
+k = jnp.pi / r[-1] + jnp.arange(len(r)) * dk
+
+
+for ElectronIonPotential, ElectronElectronPotential, mix in [
+    [
+        jaxrts.hnc_potentials.DeutschPotential(),
+        jaxrts.hnc_potentials.DeutschPotential(),
+        0.8,
+    ],
+    [
+        jaxrts.hnc_potentials.KelbgPotential(),
+        jaxrts.hnc_potentials.KelbgPotential(),
+        0.95,
+    ],
+    [
+        jaxrts.hnc_potentials.KlimontovichKraeftPotential(),
+        jaxrts.hnc_potentials.DeutschPotential(),
+        0.8,
+    ],
+    [
+        jaxrts.hnc_potentials.KlimontovichKraeftPotential(),
+        jaxrts.hnc_potentials.KelbgPotential(),
+        0.8,
+    ],
+]:
+    fig, ax = plt.subplots(2, 2, sharex="col", figsize=(6, 8))
+
+    IonIonPotential = jaxrts.hnc_potentials.CoulombPotential()
+    CoulombPotential = jaxrts.hnc_potentials.CoulombPotential()
+
+    for Potential in [
+        IonIonPotential,
+        ElectronIonPotential,
+        ElectronElectronPotential,
+        CoulombPotential,
+    ]:
+        Potential.include_electrons = True
+
+    unit = ureg.electron_volt
+    V_s = IonIonPotential.full_r(state, r).m_as(unit)
+
+    V_s = V_s.at[-1, :, :].set(
+        ElectronIonPotential.full_r(state, r)[-1, :, :].m_as(unit)
+    )
+    V_s = V_s.at[:, -1, :].set(
+        ElectronIonPotential.full_r(state, r)[:, -1, :].m_as(unit)
+    )
+    V_s = V_s.at[-1, -1, :].set(
+        ElectronElectronPotential.full_r(state, r)[-1, -1, :].m_as(unit)
+    )
+    V_s *= unit
+    V_s -= CoulombPotential.long_r(state, r)
+    ax[0, 0].plot(
+        (r / d[0, 0]).m_as(ureg.dimensionless),
+        V_s[0, 0, :].m_as(unit),
+        label="$V_{ii}$",
+    )
+    ax[0, 0].plot(
+        (r / d[1, 0]).m_as(ureg.dimensionless),
+        V_s[1, 0, :].m_as(unit),
+        label="$V_{ei}$",
+    )
+    ax[0, 0].plot(
+        (r / d[1, 1]).m_as(ureg.dimensionless),
+        V_s[1, 1, :].m_as(unit),
+        label="$V_{ee}$",
+    )
+
+    unit = ureg.electron_volt * ureg.angstrom**3
+    V_l_k = CoulombPotential.long_k(state, k).m_as(unit)
+
+    ax[0, 1].plot(
+        (k * d[0, 0]).m_as(ureg.dimensionless),
+        V_l_k[0, 0, :],
+        label="$V_{ii}$",
+    )
+    ax[0, 1].plot(
+        (k * d[1, 0]).m_as(ureg.dimensionless),
+        V_l_k[1, 0, :],
+        label="$V_{ei}$",
+    )
+    ax[0, 1].plot(
+        (k * d[1, 1]).m_as(ureg.dimensionless),
+        V_l_k[1, 1, :],
+        label="$V_{ee}$",
+    )
+    V_l_k *= unit
+
+    n = jaxrts.units.to_array([*state.n_i, state.n_e])
+
+    g, niter = jaxrts.hypernetted_chain.pair_distribution_function_HNC(
+        V_s, V_l_k, r, IonIonPotential.T(state), n, mix=mix
+    )
+    S_ii = jaxrts.hypernetted_chain.S_ii_HNC(k, g, n, r)
+
+    # The Fist value should not be trusted
+    ax[1, 1].plot(
+        (k[1:] * d[0, 0]).m_as(ureg.dimensionless),
+        S_ii[0, 0, 1:].m_as(ureg.dimensionless),
+        label="$S_{ii}$",
+    )
+    ax[1, 1].plot(
+        (k[1:] * d[1, 0]).m_as(ureg.dimensionless),
+        S_ii[1, 0, 1:].m_as(ureg.dimensionless),
+        label="$S_{ei}$",
+    )
+    ax[1, 1].plot(
+        (k[1:] * d[1, 1]).m_as(ureg.dimensionless),
+        S_ii[1, 1, 1:].m_as(ureg.dimensionless),
+        label="$S_{ee}$",
+    )
+    ax[1, 0].plot(
+        (r / d[0, 0]).m_as(ureg.dimensionless),
+        g[0, 0, :].m_as(ureg.dimensionless),
+        label="$g_{ii}$",
+    )
+    ax[1, 0].plot(
+        (r / d[1, 0]).m_as(ureg.dimensionless),
+        g[1, 0, :].m_as(ureg.dimensionless),
+        label="$g_{ei}$",
+    )
+    ax[1, 0].plot(
+        (r / d[1, 1]).m_as(ureg.dimensionless),
+        g[1, 1, :].m_as(ureg.dimensionless),
+        label="$g_{ee}$",
+    )
+
+    ax[1, 0].set_xlim(0, 3)
+    ax[1, 1].set_xlim(0, 13)
+
+    ax[1, 1].set_xlabel("$k$ [1/a$_i$]")
+    ax[1, 0].set_xlabel("$r$ [a$_i$]")
+
+    ax[0, 0].set_title("Short-ranged Potential")
+    ax[0, 1].set_xlabel("long-ranged Potential (FT)")
+    ax[1, 0].set_xlabel("Pair distribution function")
+    ax[1, 1].set_xlabel("Static structure factor")
+
+    for axis in ax.flatten():
+        axis.legend()
+
+    fig.suptitle(
+        f"e-i Potential: {ElectronIonPotential.__name__}, e-e Potential: {ElectronElectronPotential.__name__}"  # noqa: 501f
+    )
+
+plt.tight_layout()
+plt.show()

--- a/doc/examples/ionic/plot_HNC_exchange.py
+++ b/doc/examples/ionic/plot_HNC_exchange.py
@@ -1,0 +1,158 @@
+"""
+HNC calculations with Quantum exchange potentials
+=================================================
+
+This example shows the usage of the
+:py:class:`jaxrts.hnc_potentials.SpinAveragedEEExchange` potential, reproducing
+Fig. 6 from :cite:`Wunsch.2008`.
+
+This example also shows how :py:class:`jaxrts.hnc_potentials.HNCPotential`
+objects can be added.
+"""
+
+import jax.numpy as jnp
+import jaxrts
+import jpu
+
+import matplotlib.pyplot as plt
+import scienceplots  # noqa: F401
+
+plt.style.use("science")
+
+ureg = jaxrts.ureg
+
+element = jaxrts.Element("Be")
+
+state = jaxrts.PlasmaState(
+    ions=[element],
+    Z_free=[2.2],
+    mass_density=[1.23e23] / (1 * ureg.centimeter**3) * element.atomic_mass,
+    T_e=1.39e5 * ureg.kelvin,
+)
+
+# Increasing max(r) results in better fits for the Sii@low k, but increases
+# computation time
+pot = 16
+r = jpu.numpy.linspace(1e-2 * ureg.a0, 3e3 * ureg.a0, 2**pot)
+mix = 0.4
+
+d = jpu.numpy.cbrt(
+    3 / (4 * jnp.pi * (state.n_i[:, jnp.newaxis] + state.n_i[jnp.newaxis, :]))
+)
+
+dr = r[1] - r[0]
+dk = jnp.pi / (len(r) * dr)
+k = jnp.pi / r[-1] + jnp.arange(len(r)) * dk
+
+fig, ax = plt.subplots(2, 1, figsize=(6, 8))
+
+for ElectronIonPotential, ElectronElectronPotential, ls in [
+    [
+        jaxrts.hnc_potentials.DeutschPotential(),
+        jaxrts.hnc_potentials.DeutschPotential(),
+        "solid",
+    ],
+    [
+        jaxrts.hnc_potentials.DeutschPotential(),
+        jaxrts.hnc_potentials.DeutschPotential()
+        + jaxrts.hnc_potentials.SpinAveragedEEExchange(),
+        "dashed",
+    ],
+]:
+
+    IonIonPotential = jaxrts.hnc_potentials.CoulombPotential()
+    CoulombPotential = jaxrts.hnc_potentials.CoulombPotential()
+
+    for Potential in [
+        IonIonPotential,
+        ElectronIonPotential,
+        ElectronElectronPotential,
+        CoulombPotential,
+    ]:
+        Potential.include_electrons = True
+
+    unit = ureg.electron_volt
+    V_s = IonIonPotential.full_r(state, r).m_as(unit)
+
+    V_s = V_s.at[-1, :, :].set(
+        ElectronIonPotential.full_r(state, r)[-1, :, :].m_as(unit)
+    )
+    V_s = V_s.at[:, -1, :].set(
+        ElectronIonPotential.full_r(state, r)[:, -1, :].m_as(unit)
+    )
+    V_s = V_s.at[-1, -1, :].set(
+        ElectronElectronPotential.full_r(state, r)[-1, -1, :].m_as(unit)
+    )
+    V_s *= unit
+    V_s -= CoulombPotential.long_r(state, r)
+
+    unit = ureg.electron_volt * ureg.angstrom**3
+    V_l_k = CoulombPotential.long_k(state, k)
+
+    n = jaxrts.units.to_array([*state.n_i, state.n_e])
+
+    g, niter = jaxrts.hypernetted_chain.pair_distribution_function_HNC(
+        V_s, V_l_k, r, IonIonPotential.T(state), n, mix=mix
+    )
+    S_ii = jaxrts.hypernetted_chain.S_ii_HNC(k, g, n, r)
+
+    # The Fist value should not be trusted
+    ax[1].plot(
+        (k[1:] * d[0, 0]).m_as(ureg.dimensionless),
+        S_ii[0, 0, 1:].m_as(ureg.dimensionless),
+        label="$ii$" if ls == "solid" else None,
+        color="C0",
+        ls=ls,
+    )
+    ax[1].plot(
+        (k[1:] * d[1, 0]).m_as(ureg.dimensionless),
+        S_ii[1, 0, 1:].m_as(ureg.dimensionless),
+        label="$ei$" if ls == "solid" else None,
+        color="C1",
+        ls=ls,
+    )
+    ax[1].plot(
+        (k[1:] * d[1, 1]).m_as(ureg.dimensionless),
+        S_ii[1, 1, 1:].m_as(ureg.dimensionless),
+        label="$ee$" if ls == "solid" else None,
+        color="C2",
+        ls=ls,
+    )
+    try:
+        pot_label = ElectronElectronPotential.description
+    except AttributeError:
+        pot_label = ElectronElectronPotential.__name__
+
+    ax[0].plot(
+        (r / d[0, 0]).m_as(ureg.dimensionless),
+        g[0, 0, :].m_as(ureg.dimensionless),
+        label=pot_label,
+        color="C0",
+        ls=ls,
+    )
+    ax[0].plot(
+        (r / d[1, 0]).m_as(ureg.dimensionless),
+        g[1, 0, :].m_as(ureg.dimensionless),
+        color="C1",
+        ls=ls,
+    )
+    ax[0].plot(
+        (r / d[1, 1]).m_as(ureg.dimensionless),
+        g[1, 1, :].m_as(ureg.dimensionless),
+        color="C2",
+        ls=ls,
+    )
+
+    ax[0].set_title("$g_{ab}(r)$")
+    ax[0].set_xlabel("$r$ [a$_i$]")
+    ax[0].set_xlim(0, 2.5)
+    ax[0].set_ylim(0, 2.5)
+    ax[1].set_title("$S_{ab}(k)$")
+    ax[1].set_xlabel("$k$ [1/a$_i$]")
+    ax[1].set_xlim(0, 7)
+
+    for axis in ax.flatten():
+        axis.legend()
+
+plt.tight_layout()
+plt.show()

--- a/doc/source/literature.bib
+++ b/doc/source/literature.bib
@@ -515,7 +515,6 @@ eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rspa.1957.0106}
   month = {Jul},
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevA.26.603},
-  url = {https://link.aps.org/doi/10.1103/PhysRevA.26.603}  [Titel anhand dieser DOI in Citavi-Projekt übernehmen] 
 }
 
 @article{Farid.1993,
@@ -531,4 +530,17 @@ eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rspa.1957.0106}
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevB.48.11602},
   url = {https://link.aps.org/doi/10.1103/PhysRevB.48.11602}
+}
+@article{Wunsch.2008,
+  author = {W{\"u}nsch, K. and Hilse, P. and Schlanges, M. and Gericke, D. O.},
+  doi = {10.1103/physreve.77.056404},
+  issue = {5},
+  journal = {Physical Review E},
+  language = {english},
+  month = {5},
+  publisher = {American Physical Society (APS)},
+  title = {Structure of strongly coupled multicomponent plasmas},
+  url = {http://dx.doi.org/10.1103/physreve.77.056404},
+  volume = {77},
+  year = {2008},
 }

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -361,10 +361,19 @@ _3Dfour = _3Dfour_sine
 
 
 @jax.jit
-def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni):
+def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni, mix=0.0):
     """
     Calculate the Pair distribution function in the Hypernetted Chain approach,
     as it was published by :cite:`Wunsch.2011`.
+
+    The `mix` argument should lie within the interval [0, 1) and controls
+    the amount by which the short-range nodal diagram term `N_ab` is updated
+    with each iteration. `mix=0` corresponds to fully using the newly obtained
+    result, while increasing `mix` mixes more of the previous iteration's value
+    to `N_ab`. This addition to the HNC scheme presented by :cite:`Wunsch.2011`
+    was introduced in the MCSS User Guide :cite:`Chapman.2016` and is
+    especially relevant e.g., at low temperatures, where the HNC scheme becomes
+    numerically unstable.
     """
     delta = 1e-6
 
@@ -421,7 +430,7 @@ def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni):
 
         Ns_k = h_k - cs_k
 
-        Ns_r_new = (
+        Ns_r_new_full = (
             _3Dfour(
                 r,
                 k,
@@ -429,6 +438,8 @@ def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni):
             )
             / (2 * jnp.pi) ** 3
         )
+
+        Ns_r_new = (1 - mix) * Ns_r_new_full + mix * Ns_r
 
         log_g_r_new = Ns_r_new - v_s
 

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -538,7 +538,7 @@ class OnePotentialHNCIonFeat(IonFeatModel):
         # Interpolate this to the k given by the setup
 
         S_ab = hypernetted_chain.hnc_interp(setup.k, self.k, S_ab_HNC)
-     
+
         return S_ab
 
     # The following is required to jit a Model
@@ -2202,11 +2202,7 @@ class FiniteWavelengthScreening(Model):
         )
         q = jnp.real(q.m_as(ureg.dimensionless))
         # Screening vanishes if there are no free electrons
-        q = jnpu.where(
-            plasma_state.Z_free == 0,
-            0,
-            q[:, 0]
-        )[:, jnp.newaxis]
+        q = jnpu.where(plasma_state.Z_free == 0, 0, q[:, 0])[:, jnp.newaxis]
         return q
 
 
@@ -2240,11 +2236,7 @@ class DebyeHueckelScreening(Model):
         )
         q = jnp.real(q.m_as(ureg.dimensionless))
         # Screening vanishes if there are no free electrons
-        q = jnpu.where(
-            plasma_state.Z_free == 0,
-            0,
-            q[:, 0]
-        )[:, jnp.newaxis]
+        q = jnpu.where(plasma_state.Z_free == 0, 0, q[:, 0])[:, jnp.newaxis]
         return q
 
 
@@ -2295,11 +2287,7 @@ class LinearResponseScreening(Model):
         q = xi * Vei[-1, :-1]
         q = jnp.real(q.m_as(ureg.dimensionless))
         # Screening vanishes if there are no free electrons
-        q = jnpu.where(
-            plasma_state.Z_free == 0,
-            0,
-            q[:, 0]
-        )[:, jnp.newaxis]
+        q = jnpu.where(plasma_state.Z_free == 0, 0, q[:, 0])[:, jnp.newaxis]
         return q
 
 
@@ -2335,11 +2323,7 @@ class Gregori2004Screening(Model):
         )[:, jnp.newaxis]
         q = jnp.real(q.m_as(ureg.dimensionless))
         # Screening vanishes if there are no free electrons
-        q = jnpu.where(
-            plasma_state.Z_free == 0,
-            0,
-            q[:, 0]
-        )[:, jnp.newaxis]
+        q = jnpu.where(plasma_state.Z_free == 0, 0, q[:, 0])[:, jnp.newaxis]
         return q
 
 

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -477,6 +477,7 @@ class OnePotentialHNCIonFeat(IonFeatModel):
         rmin: Quantity = 0.001 * ureg.a_0,
         rmax: Quantity = 100 * ureg.a_0,
         pot: int = 14,
+        mix: float = 0.0,
     ) -> None:
         #: The minimal radius for evaluating the potentials.
         self.r_min: Quantity = rmin
@@ -485,6 +486,12 @@ class OnePotentialHNCIonFeat(IonFeatModel):
         #: The exponent (``2 ** pot``), setting the number of points in ``r``
         #: or ``k`` to evaluate.
         self.pot: int = pot
+        #: Value in [0, 1); desribes how much of the last iterations' nodal
+        #: correction term should be added to the newly obtained `N_ab`. A
+        #: value of zero corresponds to no parts of the old solution. Can be
+        #: increased when HNC becomes numerically unstable due to high coupling
+        #: strengths.
+        self.mix: float = mix
         super().__init__()
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
@@ -536,7 +543,7 @@ class OnePotentialHNCIonFeat(IonFeatModel):
 
     # The following is required to jit a Model
     def _tree_flatten(self):
-        children = (self.r_min, self.r_max)
+        children = (self.r_min, self.r_max, self.mix)
         aux_data = (
             self.model_key,
             self.pot,
@@ -547,7 +554,7 @@ class OnePotentialHNCIonFeat(IonFeatModel):
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
         obj.model_key, obj.pot = aux_data
-        obj.r_min, obj.r_max = children
+        obj.r_min, obj.r_max, obj.mix = children
 
         return obj
 
@@ -596,6 +603,7 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
         rmin: Quantity = 0.001 * ureg.a_0,
         rmax: Quantity = 100 * ureg.a_0,
         pot: int = 14,
+        mix: float = 0.0,
     ) -> None:
         #: The minimal radius for evaluating the potentials.
         self.r_min: Quantity = rmin
@@ -604,6 +612,12 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
         #: The exponent (``2 ** pot``), setting the number of points in ``r``
         #: or ``k`` to evaluate.
         self.pot: int = pot
+        #: Value in [0, 1); desribes how much of the last iterations' nodal
+        #: correction term should be added to the newly obtained `N_ab`. A
+        #: value of zero corresponds to no parts of the old solution. Can be
+        #: increased when HNC becomes numerically unstable due to high coupling
+        #: strengths.
+        self.mix: float = mix
         super().__init__()
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
@@ -770,7 +784,7 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
 
     # The following is required to jit a Model
     def _tree_flatten(self):
-        children = (self.r_min, self.r_max)
+        children = (self.r_min, self.r_max, self.mix)
         aux_data = (
             self.model_key,
             self.pot,
@@ -781,7 +795,7 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
         obj.model_key, obj.pot = aux_data
-        obj.r_min, obj.r_max = children
+        obj.r_min, obj.r_max, obj.mix = children
 
         return obj
 


### PR DESCRIPTION
Introduce Quantum Pseudopotentials for HNC, reproducing the work of Wünsch et al, 2008.

This additionally introduces mixing in the HNC scheme to allow for convergence when the HNC scheme is numerically unstable, and allows for adding and multiplying a constant to HNCPotentials.