### PR TITLE
Fix Dandrea Fit

### DIFF
--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1017,7 +1017,7 @@ class RPA_DandreaFit(FreeFreeModel):
             plasma_state.T_e,
             plasma_state.n_e,
             interpE,
-            plasma_state["ee-lfc"].evaluate_fullk(plasma_state, setup),
+            plasma_state["ee-lfc"].evaluate(plasma_state, setup),
         )
 
         See_0 = jnpu.where(


### PR DESCRIPTION
A dimensionality error occured when calculating S_ee for small energy transfers in the Dandrea fit, to interpolate nan values. This is fixed by not using the energy-corrected k for these values