### PR TITLE
jpu.numpy to jnpu

### DIFF
--- a/doc/examples/ionic/plot_HNC_ThreePotential_Wuensch.py
+++ b/doc/examples/ionic/plot_HNC_ThreePotential_Wuensch.py
@@ -31,7 +31,13 @@ pot = 16
 r = jnpu.linspace(1e-1 * ureg.a0, 5e3 * ureg.a0, 2**pot)
 
 d = jnpu.cbrt(
-    3 / (4 * jnp.pi * (state.n_i[:, jnp.newaxis] + state.n_i[jnp.newaxis, :])/2)
+    3
+    / (
+        4
+        * jnp.pi
+        * (state.n_i[:, jnp.newaxis] + state.n_i[jnp.newaxis, :])
+        / 2
+    )
 )
 
 dr = r[1] - r[0]

--- a/doc/examples/ionic/plot_HNC_ThreePotential_Wuensch.py
+++ b/doc/examples/ionic/plot_HNC_ThreePotential_Wuensch.py
@@ -11,7 +11,7 @@ interaction.
 
 import jax.numpy as jnp
 import jaxrts
-import jpu
+import jpu.numpy as jnpu
 
 import matplotlib.pyplot as plt
 import scienceplots  # noqa: F401
@@ -28,9 +28,9 @@ state = jaxrts.PlasmaState(
 )
 
 pot = 16
-r = jpu.numpy.linspace(1e-1 * ureg.a0, 5e3 * ureg.a0, 2**pot)
+r = jnpu.linspace(1e-1 * ureg.a0, 5e3 * ureg.a0, 2**pot)
 
-d = jpu.numpy.cbrt(
+d = jnpu.cbrt(
     3 / (4 * jnp.pi * (state.n_i[:, jnp.newaxis] + state.n_i[jnp.newaxis, :])/2)
 )
 

--- a/doc/examples/ionic/plot_HNC_electron_ion_potential.py
+++ b/doc/examples/ionic/plot_HNC_electron_ion_potential.py
@@ -17,7 +17,7 @@ This plot shows quite plainly, notable differences between various models.
 """
 
 import jax.numpy as jnp
-import jpu
+import jpu.numpy as jnpu
 import matplotlib.pyplot as plt
 
 import jaxrts
@@ -54,7 +54,7 @@ lambda_ab = -KK.q2(state) / (4 * jnp.pi * ureg.epsilon_0 * 5 * ureg.rydberg)
 
 
 n = jaxrts.units.to_array([state.n_i[0], state.n_e])
-d = jpu.numpy.cbrt(
+d = jnpu.cbrt(
     3 / (4 * jnp.pi * (n[:, jnp.newaxis] + n[jnp.newaxis, :]) / 2)
 )
 

--- a/doc/examples/ionic/plot_HNC_electron_ion_potential.py
+++ b/doc/examples/ionic/plot_HNC_electron_ion_potential.py
@@ -54,9 +54,7 @@ lambda_ab = -KK.q2(state) / (4 * jnp.pi * ureg.epsilon_0 * 5 * ureg.rydberg)
 
 
 n = jaxrts.units.to_array([state.n_i[0], state.n_e])
-d = jnpu.cbrt(
-    3 / (4 * jnp.pi * (n[:, jnp.newaxis] + n[jnp.newaxis, :]) / 2)
-)
+d = jnpu.cbrt(3 / (4 * jnp.pi * (n[:, jnp.newaxis] + n[jnp.newaxis, :]) / 2))
 
 print(lambda_ab.to(ureg.angstrom))
 

--- a/doc/examples/ionic/plot_HNC_exchange.py
+++ b/doc/examples/ionic/plot_HNC_exchange.py
@@ -12,7 +12,7 @@ objects can be added.
 
 import jax.numpy as jnp
 import jaxrts
-import jpu
+import jpu.numpy as jnpu
 
 import matplotlib.pyplot as plt
 import scienceplots  # noqa: F401
@@ -33,10 +33,10 @@ state = jaxrts.PlasmaState(
 # Increasing max(r) results in better fits for the Sii@low k, but increases
 # computation time
 pot = 16
-r = jpu.numpy.linspace(5e-2 * ureg.a0, 1e3 * ureg.a0, 2**pot)
+r = jnpu.linspace(5e-2 * ureg.a0, 1e3 * ureg.a0, 2**pot)
 mix = 0.9
 
-d = jpu.numpy.cbrt(3 / (4 * jnp.pi * state.n_i))
+d = jnpu.cbrt(3 / (4 * jnp.pi * state.n_i))
 
 dr = r[1] - r[0]
 dk = jnp.pi / (len(r) * dr)

--- a/doc/examples/ionic/plot_HNC_multicomponent.py
+++ b/doc/examples/ionic/plot_HNC_multicomponent.py
@@ -9,7 +9,7 @@ use the HNC approximation with different ion species.
 from pathlib import Path
 
 import jax.numpy as jnp
-import jpu
+import jpu.numpy as jnpu
 import matplotlib.pyplot as plt
 import numpy as onp
 
@@ -35,10 +35,10 @@ state = jaxrts.PlasmaState(
 )
 
 pot = 15
-r = jpu.numpy.linspace(0.0001 * ureg.angstrom, 1000 * ureg.a0, 2**pot)
+r = jnpu.linspace(0.0001 * ureg.angstrom, 1000 * ureg.a0, 2**pot)
 
 # We add densities, here. Maybe this is wrong.
-d = jpu.numpy.cbrt(
+d = jnpu.cbrt(
     3 / (4 * jnp.pi * (state.n_i[:, jnp.newaxis] + state.n_i[jnp.newaxis, :]))
 )
 

--- a/doc/examples/ionic/plot_HNC_pair_correlation_functions.py
+++ b/doc/examples/ionic/plot_HNC_pair_correlation_functions.py
@@ -14,7 +14,7 @@ Figure in the literature by :cite:`Wunsch.2011`.
 """
 
 import jax.numpy as jnp
-import jpu
+import jpu.numpy as jnpu
 import matplotlib.pyplot as plt
 
 import jaxrts
@@ -35,7 +35,7 @@ state = jaxrts.PlasmaState(
 
 for idx, Gamma in enumerate([1, 10, 30, 100]):
     pot = [13, 13, 15, 16][idx]
-    r = jpu.numpy.linspace(0.0001 * ureg.angstrom, 100 * ureg.a0, 2**pot)
+    r = jnpu.linspace(0.0001 * ureg.angstrom, 100 * ureg.a0, 2**pot)
     dr = r[1] - r[0]
     dk = jnp.pi / (len(r) * dr)
     k = jnp.pi / r[-1] + jnp.arange(len(r)) * dk
@@ -55,7 +55,7 @@ for idx, Gamma in enumerate([1, 10, 30, 100]):
     n = jaxrts.units.to_array([n])
     state.mass_density = dens
 
-    d = jpu.numpy.cbrt(
+    d = jnpu.cbrt(
         3
         / (
             4

--- a/doc/examples/ionic/plot_HNC_potentials.py
+++ b/doc/examples/ionic/plot_HNC_potentials.py
@@ -12,9 +12,7 @@ from jaxrts import ureg
 
 plt.style.use("science")
 
-r = jnpu.linspace(0.001 * ureg.angstrom, 10 * ureg.a0, 2**12).to(
-    ureg.angstrom
-)
+r = jnpu.linspace(0.001 * ureg.angstrom, 10 * ureg.a0, 2**12).to(ureg.angstrom)
 
 dr = r[1] - r[0]
 dk = jnp.pi / (len(r) * dr)

--- a/doc/examples/ionic/plot_HNC_potentials.py
+++ b/doc/examples/ionic/plot_HNC_potentials.py
@@ -4,7 +4,7 @@ HNC: Potentials
 """
 
 import jax.numpy as jnp
-import jpu
+import jpu.numpy as jnpu
 import matplotlib.pyplot as plt
 
 import jaxrts
@@ -12,7 +12,7 @@ from jaxrts import ureg
 
 plt.style.use("science")
 
-r = jpu.numpy.linspace(0.001 * ureg.angstrom, 10 * ureg.a0, 2**12).to(
+r = jnpu.linspace(0.001 * ureg.angstrom, 10 * ureg.a0, 2**12).to(
     ureg.angstrom
 )
 

--- a/src/jaxrts/free_free.py
+++ b/src/jaxrts/free_free.py
@@ -8,7 +8,6 @@ from functools import partial
 from typing import List
 
 import jax
-import jpu
 from jax import jit
 from jax import numpy as jnp
 from jpu import numpy as jnpu
@@ -106,16 +105,16 @@ def dielectric_function_salpeter(
 
     omega = (E / (1 * ureg.planck_constant / (2 * jnp.pi))).to_base_units()
 
-    v_t = jpu.numpy.sqrt(
+    v_t = jnpu.sqrt(
         ((1 * ureg.boltzmann_constant) * T_e) / (1 * ureg.electron_mass)
     ).to_base_units()
 
-    x_e = (omega / (jpu.numpy.sqrt(2) * k * v_t)).to_base_units()
+    x_e = (omega / (jnpu.sqrt(2) * k * v_t)).to_base_units()
 
     kappa = (
         (1 * ureg.planck_constant / (2 * jnp.pi))
         * k
-        / (2 * jpu.numpy.sqrt(2) * (1 * ureg.electron_mass) * v_t)
+        / (2 * jnpu.sqrt(2) * (1 * ureg.electron_mass) * v_t)
     ).to_base_units()
 
     # The electron plasma frequency
@@ -179,7 +178,7 @@ def S0ee_from_dielectric_func_FDT(
 
     res = -(
         (1 * ureg.hbar)
-        / (1 - jpu.numpy.exp(-(E / (1 * ureg.boltzmann_constant * T_e))))
+        / (1 - jnpu.exp(-(E / (1 * ureg.boltzmann_constant * T_e))))
         * (
             ((1 * ureg.vacuum_permittivity) * k**2)
             / (jnp.pi * (1 * ureg.elementary_charge) ** 2 * n_e)
@@ -236,7 +235,7 @@ def S0ee_from_susceptibility_FDT(
     Vee = coulomb_potential_fourier(-1, -1, k)
     res = -(
         ((1 * ureg.hbar) / (jnp.pi * n_e * Vee))
-        / (1 - jpu.numpy.exp(-(E / (1 * ureg.boltzmann_constant * T_e))))
+        / (1 - jnpu.exp(-(E / (1 * ureg.boltzmann_constant * T_e))))
         * jnp.imag((susceptibility * Vee).m_as(ureg.dimensionless))
     ).to_base_units()
 
@@ -1050,13 +1049,13 @@ def inverse_screening_length_exact(T: Quantity, chem_pot: Quantity):
     )
     integral_debye *= (1 * ureg.electron_volt) ** (1 / 2)
 
-    return jpu.numpy.sqrt(prefactor_debye * integral_debye)
+    return jnpu.sqrt(prefactor_debye * integral_debye)
 
 
 @jit
 def inverse_screening_length_non_degenerate(n_e: Quantity, T: Quantity):
 
-    return jpu.numpy.sqrt(
+    return jnpu.sqrt(
         n_e
         * ureg.elementary_charge**2
         / (ureg.epsilon_0 * ureg.boltzmann_constant * T)

--- a/src/jaxrts/hnc_potentials.py
+++ b/src/jaxrts/hnc_potentials.py
@@ -37,6 +37,7 @@ from jaxrts.units import Quantity, to_array, ureg
 
 logger = logging.getLogger(__name__)
 
+
 @jax.jit
 def pauli_potential_from_classical_map_SpinAveraged(
     r1: jnp.ndarray, r2: jnp.ndarray, n_e: Quantity, T: Quantity
@@ -105,17 +106,21 @@ def pauli_potential_from_classical_map_SpinAveraged(
     cs_k = h0_T_k - N_k
     c_k = h0_T_k / (1 + n_e * h0_T_k)
 
-    potential = ((cs_k - c_k) * (1 * ureg.boltzmann_constant * T))
+    potential = (cs_k - c_k) * (1 * ureg.boltzmann_constant * T)
 
     # Interpolate values close to origin to fix divergences
 
-    index1 = jnp.argmax(jnp.where(k2.m_as(1 / ureg.angstrom) < 0.8, jnp.arange(k2.size), -1.0))
-    index2 = jnp.argmax(jnp.where(k2.m_as(1 / ureg.angstrom) < 1.0, jnp.arange(k2.size), -1.0))
+    index1 = jnp.argmax(
+        jnp.where(k2.m_as(1 / ureg.angstrom) < 0.8, jnp.arange(k2.size), -1.0)
+    )
+    index2 = jnp.argmax(
+        jnp.where(k2.m_as(1 / ureg.angstrom) < 1.0, jnp.arange(k2.size), -1.0)
+    )
 
-    f1 = potential.at[index1].get() * 1 * ureg.electron_volt * ureg.a0 **3
-    f2 = potential.at[index2].get() * 1 * ureg.electron_volt * ureg.a0 **3
-    x1 = k2.at[index1].get() / (1 * ureg.a0) 
-    x2 = k2.at[index2].get() / (1 * ureg.a0) 
+    f1 = potential.at[index1].get() * 1 * ureg.electron_volt * ureg.a0**3
+    f2 = potential.at[index2].get() * 1 * ureg.electron_volt * ureg.a0**3
+    x1 = k2.at[index1].get() / (1 * ureg.a0)
+    x2 = k2.at[index2].get() / (1 * ureg.a0)
 
     def interp_func(x):
 
@@ -225,14 +230,18 @@ def pauli_potential_from_classical_map_SpinSeparated(
 
     potential = (cs_k - c_k) * (1 * ureg.boltzmann_constant * T)
 
-    index1 = jnp.argmax(jnp.where(k2.m_as(1 / ureg.angstrom) < 1.0, jnp.arange(k2.size), -1.0))
-    index2 = jnp.argmax(jnp.where(k2.m_as(1 / ureg.angstrom) < 2.0, jnp.arange(k2.size), -1.0))
+    index1 = jnp.argmax(
+        jnp.where(k2.m_as(1 / ureg.angstrom) < 1.0, jnp.arange(k2.size), -1.0)
+    )
+    index2 = jnp.argmax(
+        jnp.where(k2.m_as(1 / ureg.angstrom) < 2.0, jnp.arange(k2.size), -1.0)
+    )
 
-    f1 = potential.at[1,1, index1].get() * 1 * ureg.electron_volt * ureg.a0 **3
-    
-    f2 = potential.at[1,1, index2].get() * 1 * ureg.electron_volt * ureg.a0 **3
+    f1 = potential.at[1, 1, index1].get() * 1 * ureg.electron_volt * ureg.a0**3
 
-    x1 = k2.at[index1].get() / (1 * ureg.a0) 
+    f2 = potential.at[1, 1, index2].get() * 1 * ureg.electron_volt * ureg.a0**3
+
+    x1 = k2.at[index1].get() / (1 * ureg.a0)
     x2 = k2.at[index2].get() / (1 * ureg.a0)
 
     def interp_func(x):
@@ -1388,8 +1397,10 @@ class PauliClassicalMap(HNCPotential):
                 * ureg.angstrom**3
             )
         elif self.include_electrons == "SpinAveraged":
-            k_, exchange, g0_T_r = pauli_potential_from_classical_map_SpinAveraged(
-                r_calc, _r, plasma_state.n_e, plasma_state.T_e
+            k_, exchange, g0_T_r = (
+                pauli_potential_from_classical_map_SpinAveraged(
+                    r_calc, _r, plasma_state.n_e, plasma_state.T_e
+                )
             )
 
             # Set the parts that are not electron_electron exchange to zero
@@ -1427,8 +1438,8 @@ class PauliClassicalMap(HNCPotential):
 
         # f1 = V_P_r.m_as(ureg.electron_volt).at[index1].get() * 1 * ureg.electron_volt
         # f2 = V_P_r.m_as(ureg.electron_volt).at[index2].get() * 1 * ureg.electron_volt
-        # x1 = r.m_as(ureg.a0).at[index1].get() * (1 * ureg.a0) 
-        # x2 = r.m_as(ureg.a0).at[index2].get() * (1 * ureg.a0) 
+        # x1 = r.m_as(ureg.a0).at[index1].get() * (1 * ureg.a0)
+        # x2 = r.m_as(ureg.a0).at[index2].get() * (1 * ureg.a0)
 
         # def interp_func(x):
 
@@ -1436,7 +1447,6 @@ class PauliClassicalMap(HNCPotential):
         #     c = f1 - a * x1
 
         #     return a * x + c
-
 
         # print(interp_func(r))
         # V_P_r = jnpu.where((r.m_as(ureg.a0) < x1.m_as(ureg.a0)), interp_func(r), V_P_r)
@@ -1523,9 +1533,17 @@ class SpinAveragedEEExchange(HNCPotential):
             (ureg.k_B * self.T(plasma_state))
             * jnp.log(2)
             * jnpu.exp(
-                (-1
-                / (jnp.pi * jnp.log(2))
-                * ((_r / (self.lambda_ab(plasma_state) / jnp.sqrt(jnp.pi))).m_as(ureg.dimensionless)) ** 2)
+                (
+                    -1
+                    / (jnp.pi * jnp.log(2))
+                    * (
+                        (
+                            _r
+                            / (self.lambda_ab(plasma_state) / jnp.sqrt(jnp.pi))
+                        ).m_as(ureg.dimensionless)
+                    )
+                    ** 2
+                )
             )
             * jnp.eye(plasma_state.nions + 1)[:, :, jnp.newaxis]
         )
@@ -1533,11 +1551,7 @@ class SpinAveragedEEExchange(HNCPotential):
         exchange = (
             exchange.m_as(ureg.electron_volt)
             .at[: plasma_state.nions, : plasma_state.nions, :]
-            .set(
-                jnp.zeros(
-                    (plasma_state.nions, plasma_state.nions, len(_r))
-                )
-            )
+            .set(jnp.zeros((plasma_state.nions, plasma_state.nions, len(_r))))
             * ureg.electron_volt
         )
         return exchange
@@ -1552,8 +1566,6 @@ class SpinAveragedEEExchange(HNCPotential):
         V_P_k = _3Dfour(k, r, self.full_r(plasma_state, r))
 
         return V_P_k
-
-
 
 
 @jax.jit

--- a/src/jaxrts/hnc_potentials.py
+++ b/src/jaxrts/hnc_potentials.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 import jax
 import jax.interpreters
-import jpu
+import jpu.numpy as jnpu
 from jax import numpy as jnp
 
 from jaxrts.hypernetted_chain import (
@@ -97,7 +97,7 @@ def pauli_potential_from_classical_map_SpinAveraged(
     # g0_T_r (this is the Pauli exclusion potential by construction)
 
     h0_T_r = g0_T_r - 1
-    Ns_r = jpu.numpy.log(g0_T_r)
+    Ns_r = jnpu.log(g0_T_r)
 
     N_k = fourier_transform_sine(k2, r2, Ns_r * ureg.dimensionless)
     h0_T_k = fourier_transform_sine(k2, r2, h0_T_r * ureg.dimensionless)
@@ -124,7 +124,7 @@ def pauli_potential_from_classical_map_SpinAveraged(
 
         return a * x**2 + c
 
-    potential = jpu.numpy.where((k2 < x1), interp_func(k2), potential)
+    potential = jnpu.where((k2 < x1), interp_func(k2), potential)
 
     return k2, potential, g0_T_r
 
@@ -177,7 +177,7 @@ def pauli_potential_from_classical_map_SpinSeparated(
     #     1
     #     - (
     #         3
-    #         * (jpu.numpy.sin(k_F * r) - (k_F * r) * jpu.numpy.cos(k_F * r))
+    #         * (jnpu.sin(k_F * r) - (k_F * r) * jnpu.cos(k_F * r))
     #         / (k_F * r) ** 3
     #     ).m_as(ureg.dimensionless)
     #     ** 2
@@ -201,7 +201,7 @@ def pauli_potential_from_classical_map_SpinSeparated(
     # g0_T_r (this is the Pauli exclusion potential by construction)
 
     h0_T_r = g0_T_r - 1
-    Ns_r = jpu.numpy.log(g0_T_r)
+    Ns_r = jnpu.log(g0_T_r)
 
     N_k = _3Dfour(k2, r2, Ns_r * ureg.dimensionless)
     h0_T_k = _3Dfour(k2, r2, h0_T_r * ureg.dimensionless)
@@ -212,10 +212,10 @@ def pauli_potential_from_classical_map_SpinSeparated(
         """
         Inverted Ornstein-Zernicke Relation
         """
-        return jpu.numpy.matmul(
+        return jnpu.matmul(
             input_vec,
             jnp.linalg.inv(
-                (jnp.eye(n.shape[0]) + jpu.numpy.matmul(d, input_vec)).m_as(
+                (jnp.eye(n.shape[0]) + jnpu.matmul(d, input_vec)).m_as(
                     ureg.dimensionless
                 )
             ),
@@ -242,7 +242,7 @@ def pauli_potential_from_classical_map_SpinSeparated(
 
         return a * x**2 + c
 
-    potential = jpu.numpy.where((k2 < x1), interp_func(k2), potential)
+    potential = jnpu.where((k2 < x1), interp_func(k2), potential)
 
     # Step 3: Calculate V_(k)
     return k2, potential, g0_T_r
@@ -250,7 +250,7 @@ def pauli_potential_from_classical_map_SpinSeparated(
 
 @jax.jit
 def construct_alpha_matrix(n: jnp.ndarray | Quantity):
-    d = jpu.numpy.cbrt(
+    d = jnpu.cbrt(
         3 / (4 * jnp.pi * (n[:, jnp.newaxis] * n[jnp.newaxis, :]) ** (1 / 2))
     )
 
@@ -259,7 +259,7 @@ def construct_alpha_matrix(n: jnp.ndarray | Quantity):
 
 @jax.jit
 def construct_q_matrix(q: jnp.ndarray) -> jnp.ndarray:
-    return jpu.numpy.outer(q, q)
+    return jnpu.outer(q, q)
 
 
 class HNCPotential(metaclass=abc.ABCMeta):
@@ -285,7 +285,7 @@ class HNCPotential(metaclass=abc.ABCMeta):
             "off", "SpinAveraged", "SpinSeparated"
         ] = "off",
     ):
-        self._transform_r = jpu.numpy.linspace(1e-4, 1e4, 2**21) * ureg.a_0
+        self._transform_r = jnpu.linspace(1e-4, 1e4, 2**21) * ureg.a_0
 
         self.model_key = ""
 
@@ -322,7 +322,7 @@ class HNCPotential(metaclass=abc.ABCMeta):
 
         """
         _r = r[jnp.newaxis, jnp.newaxis, :]
-        return self.full_r(plasma_state, r) * jpu.numpy.exp(
+        return self.full_r(plasma_state, r) * jnpu.exp(
             -self.alpha(plasma_state) * _r
         )
 
@@ -338,7 +338,7 @@ class HNCPotential(metaclass=abc.ABCMeta):
         """
         _r = r[jnp.newaxis, jnp.newaxis, :]
         return self.full_r(plasma_state, r) * (
-            1 - jpu.numpy.exp(-self.alpha(plasma_state) * _r)
+            1 - jnpu.exp(-self.alpha(plasma_state) * _r)
         )
 
     @jax.jit
@@ -406,7 +406,7 @@ class HNCPotential(metaclass=abc.ABCMeta):
             )
         else:
             m = plasma_state.atomic_masses
-        mu = jpu.numpy.outer(m, m) / (m[:, jnp.newaxis] + m[jnp.newaxis, :])
+        mu = jnpu.outer(m, m) / (m[:, jnp.newaxis] + m[jnp.newaxis, :])
         return mu[:, :, jnp.newaxis]
 
     def T(self, plasma_state):
@@ -483,7 +483,7 @@ class HNCPotential(metaclass=abc.ABCMeta):
 
     def lambda_ab(self, plasma_state):
         # Compared to Gregori.2003, there is a pi missing
-        l_ab = ureg.hbar * jpu.numpy.sqrt(
+        l_ab = ureg.hbar * jnpu.sqrt(
             1 / (2 * self.mu(plasma_state) * ureg.k_B * self.T(plasma_state))
         )
         return l_ab
@@ -802,7 +802,7 @@ class DebyeHueckelPotential(HNCPotential):
         return (
             self.q2(plasma_state)
             / (4 * jnp.pi * ureg.epsilon_0 * _r)
-            * jpu.numpy.exp(-self.kappa(plasma_state) * r)
+            * jnpu.exp(-self.kappa(plasma_state) * r)
         )
 
     @jax.jit
@@ -864,7 +864,7 @@ class KelbgPotential(HNCPotential):
             / (4 * jnp.pi * ureg.epsilon_0 * _r)
             * (
                 1
-                - jpu.numpy.exp(-(_r**2) / self.lambda_ab(plasma_state) ** 2)
+                - jnpu.exp(-(_r**2) / self.lambda_ab(plasma_state) ** 2)
                 + (jnp.sqrt(jnp.pi) * _r / self.lambda_ab(plasma_state))
                 * (
                     1
@@ -896,7 +896,7 @@ class KelbgPotential(HNCPotential):
         """
         _r = r[jnp.newaxis, jnp.newaxis, :]
         c_full_r = self.q2(plasma_state) / (4 * jnp.pi * ureg.epsilon_0 * _r)
-        return c_full_r * (1 - jpu.numpy.exp(-self.alpha(plasma_state) * _r))
+        return c_full_r * (1 - jnpu.exp(-self.alpha(plasma_state) * _r))
 
     @jax.jit
     def long_k(self, plasma_state, k: Quantity):
@@ -986,7 +986,7 @@ class KelbgPotential(HNCPotential):
     #     return (
     #         self.q2(plasma_state)
     #         / (4 * jnp.pi * ureg.epsilon_0 * _r)
-    #         * (1 - jpu.numpy.exp(-(_r**2) / self.lambda_ab(plasma_state) ** 2))
+    #         * (1 - jnpu.exp(-(_r**2) / self.lambda_ab(plasma_state) ** 2))
     #     )
 
 
@@ -1036,7 +1036,7 @@ class KlimontovichKraeftPotential(HNCPotential):
         factor = ureg.k_B * self.T(plasma_state) * xi**2
         denominator = (
             16
-            * jpu.numpy.absolute(self.q2(plasma_state))
+            * jnpu.absolute(self.q2(plasma_state))
             / (4 * jnp.pi * ureg.epsilon_0)
         )
         return pref * (1 + (factor / denominator) * _r) ** (-1)
@@ -1064,7 +1064,7 @@ class DeutschPotential(HNCPotential):
             / (4 * jnp.pi * ureg.epsilon_0 * _r)
             * (
                 1
-                - jpu.numpy.exp(
+                - jnpu.exp(
                     -_r / (self.lambda_ab(plasma_state) / jnp.sqrt(jnp.pi))
                 )
             )
@@ -1110,7 +1110,7 @@ class DeutschPotential(HNCPotential):
         """
         _r = r[jnp.newaxis, jnp.newaxis, :]
         c_full_r = self.q2(plasma_state) / (4 * jnp.pi * ureg.epsilon_0 * _r)
-        return c_full_r * (1 - jpu.numpy.exp(-self.alpha(plasma_state) * _r))
+        return c_full_r * (1 - jnpu.exp(-self.alpha(plasma_state) * _r))
 
     @jax.jit
     def long_k(self, plasma_state, k: Quantity):
@@ -1186,7 +1186,7 @@ class EmptyCorePotential(HNCPotential):
             self.q2(plasma_state)
             / ureg.vacuum_permittivity
             / _k**2
-            * jpu.numpy.cos(_k * self.r_cut(plasma_state))
+            * jnpu.cos(_k * self.r_cut(plasma_state))
         )
 
     @jax.jit
@@ -1258,7 +1258,7 @@ class SoftCorePotential(HNCPotential):
 
         """
         _r = r[jnp.newaxis, jnp.newaxis, :]
-        exp_part = 1 - jpu.numpy.exp(
+        exp_part = 1 - jnpu.exp(
             -(
                 (_r / self.r_cut(plasma_state)).m_as(ureg.dimensionless)
                 ** self.beta
@@ -1283,7 +1283,7 @@ class SoftCorePotential(HNCPotential):
         _k = k[jnp.newaxis, jnp.newaxis, :]
         # Define a auxiliary short-range version of this potential; While it is
         # not used, actually, it is easier to Fourier transform.
-        exp_part = jpu.numpy.exp(
+        exp_part = jnpu.exp(
             -(
                 (self._transform_r / self.r_cut(plasma_state)).m_as(
                     ureg.dimensionless
@@ -1362,7 +1362,7 @@ class PauliClassicalMap(HNCPotential):
         _r = jnp.pi / k[-1] + jnp.arange(len(k)) * dr
 
         pot = 21
-        r_calc = jpu.numpy.linspace(1e-3 * ureg.a0, 1e4 * ureg.a0, 2**pot)
+        r_calc = jnpu.linspace(1e-3 * ureg.a0, 1e4 * ureg.a0, 2**pot)
 
         if self.include_electrons == "SpinSeparated":
 
@@ -1439,7 +1439,7 @@ class PauliClassicalMap(HNCPotential):
 
 
         # print(interp_func(r))
-        # V_P_r = jpu.numpy.where((r.m_as(ureg.a0) < x1.m_as(ureg.a0)), interp_func(r), V_P_r)
+        # V_P_r = jnpu.where((r.m_as(ureg.a0) < x1.m_as(ureg.a0)), interp_func(r), V_P_r)
 
         return V_P_r
 
@@ -1489,8 +1489,8 @@ class SpinSeparatedEEExchange(HNCPotential):
         _r = r[jnp.newaxis, jnp.newaxis, :]
         exchange = (
             (-1 * ureg.k_B * self.T(plasma_state))
-            * jpu.numpy.log(
-                1 - jpu.numpy.exp(-(_r**2 / self.lambda_ab(plasma_state) ** 2))
+            * jnpu.log(
+                1 - jnpu.exp(-(_r**2 / self.lambda_ab(plasma_state) ** 2))
             )
             * jnp.eye(len(self.mu(plasma_state)))[:, :, jnp.newaxis]
         )
@@ -1522,7 +1522,7 @@ class SpinAveragedEEExchange(HNCPotential):
         exchange = (
             (ureg.k_B * self.T(plasma_state))
             * jnp.log(2)
-            * jpu.numpy.exp(
+            * jnpu.exp(
                 (-1
                 / (jnp.pi * jnp.log(2))
                 * ((_r / (self.lambda_ab(plasma_state) / jnp.sqrt(jnp.pi))).m_as(ureg.dimensionless)) ** 2)

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -12,6 +12,7 @@ from jax import numpy as jnp
 
 from jaxrts.units import Quantity, ureg
 
+
 # Helper functions.
 @jax.jit
 def psi(t):
@@ -358,6 +359,7 @@ _3Dfour_ogata = jax.vmap(
 
 _3Dfour = _3Dfour_sine
 
+
 @jax.jit
 def pair_distribution_function_two_component_SVT_HNC_ei(
     V_s, V_l_k, r, T_ab, n, m, mix=0.0
@@ -663,7 +665,7 @@ def geometric_mean_T(T):
     """
     Returns the geometric mean of a given temperature pair, according to
     :cite:`Schwarz.2007`.
-    
+
     .. math::
 
        \\bar{T}_{ab} = \\sqrt{T_aT_b}

--- a/src/jaxrts/instrument_function.py
+++ b/src/jaxrts/instrument_function.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import jax
 import jax.numpy as jnp
-import jpu
+import jpu.numpy as jnpu
 import numpy as onp
 
 from .units import Quantity
@@ -33,7 +33,7 @@ def instrument_gaussian(
 
     """
 
-    return (1.0 / (sigma * jnp.sqrt(2 * jnp.pi))) * jpu.numpy.exp(
+    return (1.0 / (sigma * jnp.sqrt(2 * jnp.pi))) * jnpu.exp(
         -0.5 * x**2 / sigma**2
     )
 

--- a/src/jaxrts/ion_feature.py
+++ b/src/jaxrts/ion_feature.py
@@ -6,7 +6,7 @@ import logging
 
 import jax
 import jax.numpy as jnp
-import jpu
+import jpu.numpy as jnpu
 from jax import jit
 
 from .free_free import (
@@ -64,10 +64,10 @@ def q_Gregori2004(
     S_ee = S_ee_AD(k, T_e, T_i, n_e, m_ion, Z_f)
     S_ii = S_ii_AD(k, T_e, T_i, n_e, m_ion, Z_f)
 
-    C_ei = (jpu.numpy.sqrt(Z_f) * S_ei) / (S_ee * S_ii - S_ei**2)
+    C_ei = (jnpu.sqrt(Z_f) * S_ei) / (S_ee * S_ii - S_ei**2)
 
     # This would be the q given by Glenzer.2009, instead
-    # return jpu.numpy.sqrt(Z_f) * S_ei / S_ii
+    # return jnpu.sqrt(Z_f) * S_ei / S_ii
 
     return (
         C_ei
@@ -104,7 +104,7 @@ def q_Glenzer2009(
     q(k):  Quantity
         The screening charge.
     """
-    return jpu.numpy.sqrt(Z_f) * S_ei / S_ii
+    return jnpu.sqrt(Z_f) * S_ei / S_ii
 
 
 @jit

--- a/src/jaxrts/plasma_physics.py
+++ b/src/jaxrts/plasma_physics.py
@@ -180,7 +180,6 @@ def wiegner_seitz_radius(n_e: Quantity) -> Quantity:
 
 
 def chem_pot_sommerfeld_fermi_interpolation(T: Quantity, n_e: Quantity):
-
     """Interpolation function for the chemical potential of a non-interacting (ideal) fermi gas
     given in the paper of :cite:`Cowan.2019`.
     """

--- a/src/jaxrts/plasmastate.py
+++ b/src/jaxrts/plasmastate.py
@@ -210,7 +210,6 @@ class PlasmaState:
             / (1 * ureg.boltzmann_constant)
         )
 
-
         return jnpu.sqrt(Tq**2 + self.T_e**2)
 
     @property

--- a/src/jaxrts/plasmastate.py
+++ b/src/jaxrts/plasmastate.py
@@ -3,7 +3,7 @@ from abc import ABCMeta
 from typing import List
 
 import jax
-import jpu
+import jpu.numpy as jnpu
 import numpy as np
 from jax import numpy as jnp
 
@@ -85,9 +85,9 @@ class PlasmaState:
         of self.
         """
         doub_ion_list = [i for i in self.ions for _ in range(2)]
-        doub_Ti = jpu.numpy.repeat(self.T_i, 2)
-        doub_Z = jpu.numpy.repeat(self.Z_free, 2)
-        new_Z = jpu.numpy.where(
+        doub_Ti = jnpu.repeat(self.T_i, 2)
+        doub_Z = jnpu.repeat(self.Z_free, 2)
+        new_Z = jnpu.where(
             jnp.arange(len(doub_Z)) % 2 == 0,
             jnp.floor(doub_Z),
             jnp.ceil(doub_Z),
@@ -97,7 +97,7 @@ class PlasmaState:
             1 - (doub_Z - jnp.floor(doub_Z)),
             doub_Z - jnp.floor(doub_Z),
         )
-        doub_rho = jpu.numpy.repeat(self.mass_density, 2)
+        doub_rho = jnpu.repeat(self.mass_density, 2)
 
         return PlasmaState(
             doub_ion_list,
@@ -189,7 +189,7 @@ class PlasmaState:
 
     @property
     def n_e(self):
-        return (jpu.numpy.sum(self.n_i * self.Z_free)).to_base_units()
+        return (jnpu.sum(self.n_i * self.Z_free)).to_base_units()
 
     @property
     def Teff_e(self):
@@ -200,18 +200,18 @@ class PlasmaState:
         # This is another definition of Tq, not from Gregori et al.
         # Tq = (
         #     fermi_energy(self.n_e)
-        #     / (1.594 - 0.3160 * jpu.numpy.sqrt(rs) + 0.024 * rs)
+        #     / (1.594 - 0.3160 * jnpu.sqrt(rs) + 0.024 * rs)
         #     / (1 * ureg.boltzmann_constant)
         # )
 
         Tq = (
             fermi_energy(self.n_e)
-            / (1.3251 - 0.1779 * jpu.numpy.sqrt(rs))
+            / (1.3251 - 0.1779 * jnpu.sqrt(rs))
             / (1 * ureg.boltzmann_constant)
         )
 
 
-        return jpu.numpy.sqrt(Tq**2 + self.T_e**2)
+        return jnpu.sqrt(Tq**2 + self.T_e**2)
 
     @property
     def ee_coupling(self):
@@ -239,7 +239,7 @@ class PlasmaState:
 
     @property
     def ion_core_radius(self):
-        return jpu.numpy.where(
+        return jnpu.where(
             self._overwritten["ion_core_radius"] > 0 * ureg.angstrom,
             self._overwritten["ion_core_radius"],
             self._lookup_ion_core_radius(),
@@ -268,7 +268,7 @@ class PlasmaState:
         """
         Return the number fraction of the elements.
         """
-        x = self.n_i / jpu.numpy.sum(self.n_i)
+        x = self.n_i / jnpu.sum(self.n_i)
         return x.m_as(ureg.dimensionless)
 
     def db_wavelength(self, kind: List | str):
@@ -285,7 +285,7 @@ class PlasmaState:
                 wavelengths.append(
                     (
                         (1 * ureg.planck_constant)
-                        / jpu.numpy.sqrt(
+                        / jnpu.sqrt(
                             2.0
                             * jnp.pi
                             * 1
@@ -300,7 +300,7 @@ class PlasmaState:
                 wavelengths.append(
                     (
                         (1 * ureg.planck_constant)
-                        / jpu.numpy.sqrt(
+                        / jnpu.sqrt(
                             2.0
                             * jnp.pi
                             * 1

--- a/tests/test_hnc_static_structure_factors.py
+++ b/tests/test_hnc_static_structure_factors.py
@@ -1,4 +1,4 @@
-import jpu
+import jpu.numpy as jnpu
 import matplotlib.pyplot as plt
 from jax import numpy as jnp
 
@@ -28,7 +28,7 @@ def main():
             1 / ureg.angstrom**3
         )
 
-        d = jpu.numpy.cbrt(
+        d = jnpu.cbrt(
             3 / (4 * jnp.pi * (n_i[:, jnp.newaxis] + n_i[jnp.newaxis, :]) / 2)
         )
 
@@ -41,7 +41,7 @@ def main():
             / (4 * jnp.pi * 1 * ureg.epsilon_0 * d)
         ) / (1 * ureg.boltzmann_constant * T)
 
-        r = jpu.numpy.linspace(0.001 * ureg.angstrom, 1000 * ureg.a0, 2**14)
+        r = jnpu.linspace(0.001 * ureg.angstrom, 1000 * ureg.a0, 2**14)
 
         alpha = jaxrts.hnc_potentials.construct_alpha_matrix(n_i)
 

--- a/tests/test_hnc_static_structure_factors.py
+++ b/tests/test_hnc_static_structure_factors.py
@@ -32,7 +32,9 @@ def main():
             3 / (4 * jnp.pi * (n_i[:, jnp.newaxis] + n_i[jnp.newaxis, :]) / 2)
         )
 
-        q = jaxrts.hnc_potentials.construct_q_matrix(jnp.array([1]) * Z * ureg.elementary_charge)
+        q = jaxrts.hnc_potentials.construct_q_matrix(
+            jnp.array([1]) * Z * ureg.elementary_charge
+        )
 
         Gamma = (
             Z**2
@@ -55,7 +57,9 @@ def main():
         # V_l = hnc.V_screened_C_l_r(r, q, alpha)
         # V_l_k, _ = hnc.transformPotential(V_l, r)
 
-        g, niter = jaxrts.hypernetted_chain.pair_distribution_function_HNC(V_s, V_l_k, r, T, n_i)
+        g, niter = jaxrts.hypernetted_chain.pair_distribution_function_HNC(
+            V_s, V_l_k, r, T, n_i
+        )
 
         S_k = jaxrts.hypernetted_chain.S_ii_HNC(k, g, n_i, r)
 

--- a/tests/test_hypernetted_chain.py
+++ b/tests/test_hypernetted_chain.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-import jpu
+import jpu.numpy as jnpu
 import numpy as onp
 from jax import numpy as jnp
 
@@ -74,7 +74,7 @@ def test_hydrogen_pair_distribution_function_literature_values_wuensch():
     )
 
     for Gamma, pot in zip([1, 10, 30, 100], [13, 13, 15, 16]):
-        r = jpu.numpy.linspace(0.0001 * ureg.angstrom, 100 * ureg.a0, 2**pot)
+        r = jnpu.linspace(0.0001 * ureg.angstrom, 100 * ureg.a0, 2**pot)
 
         dr = r[1] - r[0]
         dk = jnp.pi / (len(r) * dr)
@@ -107,7 +107,7 @@ def test_hydrogen_pair_distribution_function_literature_values_wuensch():
             delimiter=", ",
         )
 
-        d = jpu.numpy.cbrt(
+        d = jnpu.cbrt(
             3 / (4 * jnp.pi * (n[:, jnp.newaxis] + n[jnp.newaxis, :]) / 2)
         )
         g, niter = hnc.pair_distribution_function_HNC(
@@ -172,7 +172,7 @@ def test_linear_response_screening_gericke2010_literature():
             delimiter=",",
         )
         klit *= 1 / ureg.a_0
-        q_interp = jpu.numpy.interp(klit, k, q[0, 1, :])
+        q_interp = jnpu.interp(klit, k, q[0, 1, :])
         assert (
             jnp.max(jnp.abs(q_interp.m_as(ureg.dimensionless) - qlit)) < 0.03
         )
@@ -197,10 +197,10 @@ def test_multicomponent_wunsch2011_literature():
     )
 
     pot = 15
-    r = jpu.numpy.linspace(0.0001 * ureg.angstrom, 1000 * ureg.a0, 2**pot)
+    r = jnpu.linspace(0.0001 * ureg.angstrom, 1000 * ureg.a0, 2**pot)
 
     # We add densities, here. Maybe this is wrong.
-    d = jpu.numpy.cbrt(
+    d = jnpu.cbrt(
         3
         / (
             4
@@ -238,17 +238,17 @@ def test_multicomponent_wunsch2011_literature():
             unpack=True,
             delimiter=",",
         )
-        g_interp = jpu.numpy.interp(xlit * d[0, 0], r, g[idx])
-        S_interp = jpu.numpy.interp(klit / d[0, 0], k, S_ii[idx])
+        g_interp = jnpu.interp(xlit * d[0, 0], r, g[idx])
+        S_interp = jnpu.interp(klit / d[0, 0], k, S_ii[idx])
         assert (
             jnp.max(
-                jpu.numpy.absolute(glit - g_interp).m_as(ureg.dimensionless)
+                jnpu.absolute(glit - g_interp).m_as(ureg.dimensionless)
             )
             < 0.03
         )
         assert (
             jnp.max(
-                jpu.numpy.absolute(Slit - S_interp).m_as(ureg.dimensionless)
+                jnpu.absolute(Slit - S_interp).m_as(ureg.dimensionless)
             )
             < 0.03
         )

--- a/tests/test_hypernetted_chain.py
+++ b/tests/test_hypernetted_chain.py
@@ -241,15 +241,11 @@ def test_multicomponent_wunsch2011_literature():
         g_interp = jnpu.interp(xlit * d[0, 0], r, g[idx])
         S_interp = jnpu.interp(klit / d[0, 0], k, S_ii[idx])
         assert (
-            jnp.max(
-                jnpu.absolute(glit - g_interp).m_as(ureg.dimensionless)
-            )
+            jnp.max(jnpu.absolute(glit - g_interp).m_as(ureg.dimensionless))
             < 0.03
         )
         assert (
-            jnp.max(
-                jnpu.absolute(Slit - S_interp).m_as(ureg.dimensionless)
-            )
+            jnp.max(jnpu.absolute(Slit - S_interp).m_as(ureg.dimensionless))
             < 0.03
         )
 

--- a/tests/test_saha.py
+++ b/tests/test_saha.py
@@ -6,6 +6,7 @@ import jaxrts
 import jax.numpy as jnp
 import numpy as onp
 
+
 def test_against_MALGS_calculation():
     number_fraction = jnp.array(
         [

--- a/tools/SahaPlotter/sahaplotter.py
+++ b/tools/SahaPlotter/sahaplotter.py
@@ -34,7 +34,6 @@ import jaxrts.elements
 
 import jax.numpy as jnp
 import jpu.numpy as jnpu
-import jpu
 
 import jaxrts
 


### PR DESCRIPTION
We had an inconsistent habit of importing either `jpu`, directly, or only the `jpu.numpy` sub-module `jnpu`. This impeded to move code around and resulted in annoying `ImportError`s.
This PR uses the latter import throughout the project.