### PR TITLE
Fix el. scattering intensity

### DIFF
--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -335,7 +335,8 @@ class IonFeatModel(Model):
         res = w_R * setup.instrument(
             (setup.measured_energy - setup.energy) / ureg.hbar
         )
-        return res
+        return res / plasma_state.mean_Z_A
+
 
 
 class ArkhipovIonFeat(IonFeatModel):
@@ -2629,7 +2630,7 @@ class FiniteWavelengthScreening(Model):
         q = jnp.real(q.m_as(ureg.dimensionless))
         # Screening vanishes if there are no free electrons
         q = jnpu.where(plasma_state.Z_free == 0, 0, q[:, 0])[:, jnp.newaxis]
-        return q / plasma_state.mean_Z_A
+        return q
 
 
 class DebyeHueckelScreening(Model):

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -338,7 +338,6 @@ class IonFeatModel(Model):
         return res / plasma_state.mean_Z_A
 
 
-
 class ArkhipovIonFeat(IonFeatModel):
     """
     Model for the ion feature of the scattering, presented in
@@ -2044,9 +2043,12 @@ class SchumacherImpulseFitRk(ScatteringModel):
         plasma_state: "PlasmaState",
         setup: Setup,
     ) -> jnp.ndarray:
-        return SchumacherImpulse(r_k=1.0).evaluate_raw(
+        val = SchumacherImpulse(r_k=1.0).evaluate_raw(
             plasma_state, setup
         ) * self.r_k(plasma_state, setup)
+        return jnpu.where(
+            jnp.isnan(val.m_as(ureg.second)), 0 * ureg.second, val
+        )
 
     def _tree_flatten(self):
         children = ()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -97,7 +97,9 @@ class TestSSFInstance:
     )
     test_state["ionic scattering"] = jaxrts.models.OnePotentialHNCIonFeat()
     test_state["free-free scattering"] = jaxrts.models.RPA_DandreaFit()
-    test_state["bound-free scattering"] = jaxrts.models.SchumacherImpulse()
+    test_state["bound-free scattering"] = (
+        jaxrts.models.SchumacherImpulseFitRk()
+    )
     test_state["free-bound scattering"] = jaxrts.models.DetailedBalance()
 
     def test_sff_to_unity_fully_ionized(self):
@@ -114,9 +116,8 @@ class TestSSFInstance:
 
     def test_sff_to_unity_with_bound_free_contrib(self):
         """
-        Setting r_k to auto should be fine, here, because it goes to 1 for
-        :math:`k\\rightarrow \\infty`. However, there is the binding energy and
-        further unknowns.
+        The SchumacherRkFit is using the fsum rule. Check that if that is
+        fulfilled, we reach the correct SFF limit.
         """
         self.test_state.Z_free = (
             self.test_state.Z_A - jnp.ones(len(self.test_state.ions)) * 2
@@ -128,8 +129,8 @@ class TestSSFInstance:
         ssf = jaxrts.analysis.ITCF_ssf(
             S_ee, self.test_setup, ureg("14.8keV"), raw=False
         )
-        assert jnpu.absolute(ssf_raw - 1) < 0.05
-        assert jnpu.absolute(ssf - 1) < 0.05
+        assert jnpu.absolute(ssf_raw - 1) < 0.02
+        assert jnpu.absolute(ssf - 1) < 0.02
 
 
 class TestFsumRuleInstance:


### PR DESCRIPTION
This PR Fixes a bug introduced in 31e669c6842c794561e5f5820cec9ab44fb6c225, where not the scattering intensity of the elastic scattering was divided by the mean charge, but rather the screening length.
Furthermore, a faulty test is fixed & `SchumacherImpulseFitRk` can be used if no bound electrons are in the plasma.