### PR TITLE
Test all Models

### DIFF
--- a/src/jaxrts/ipd.py
+++ b/src/jaxrts/ipd.py
@@ -304,9 +304,13 @@ def ipd_ecker_kroell(
 
     C = (
         2.2
-        * jnpu.sqrt(ureg.elementary_charge**2 / (ureg.boltzmann_constant * Te))
+        * jnpu.sqrt(
+            ureg.elementary_charge**2
+            / (ureg.boltzmann_constant * Te)
+            / (4 * jnp.pi * ureg.epsilon_0)
+        )
         * n_c ** (1 / 6)
-    )
+    ).m_as(ureg.dimensionless)
 
     ipd_c1 = -1 * ureg.elementary_charge**2 / (ureg.epsilon_0 * lambda_Di) * Zi
     ipd_c2 = -C * ureg.elementary_charge**2 / (ureg.epsilon_0 * R_0) * Zi

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -2109,6 +2109,11 @@ class DetailedBalance(ScatteringModel):
     __name__ = "DetailedBalance"
     allowed_keys = ["free-bound scattering"]
 
+    def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
+        plasma_state.update_default_model(
+            "bound-free scattering", SchumacherImpulse()
+        )
+
     @jax.jit
     def evaluate_raw(
         self, plasma_state: "PlasmaState", setup: Setup

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1283,6 +1283,10 @@ class BornMerminFull(FreeFreeModel):
             "chemical potential", IchimaruChemPotential()
         )
         plasma_state.update_default_model("BM V_eiS", FiniteWavelength_BM_V())
+        if len(plasma_state) == 1:
+            plasma_state.update_default_model("BM S_ii", Sum_Sii())
+        else:
+            plasma_state.update_default_model("BM S_ii", AverageAtom_Sii())
 
     @jax.jit
     def evaluate_raw(
@@ -1420,6 +1424,10 @@ class BornMermin(FreeFreeModel):
             "chemical potential", IchimaruChemPotential()
         )
         plasma_state.update_default_model("BM V_eiS", FiniteWavelength_BM_V())
+        if len(plasma_state) == 1:
+            plasma_state.update_default_model("BM S_ii", Sum_Sii())
+        else:
+            plasma_state.update_default_model("BM S_ii", AverageAtom_Sii())
 
     @jax.jit
     def evaluate_raw(
@@ -1576,6 +1584,10 @@ class BornMermin_Fit(FreeFreeModel):
             "chemical potential", IchimaruChemPotential()
         )
         plasma_state.update_default_model("BM V_eiS", FiniteWavelength_BM_V())
+        if len(plasma_state) == 1:
+            plasma_state.update_default_model("BM S_ii", Sum_Sii())
+        else:
+            plasma_state.update_default_model("BM S_ii", AverageAtom_Sii())
 
     @jax.jit
     def evaluate_raw(
@@ -1733,6 +1745,10 @@ class BornMermin_Fortmann(FreeFreeModel):
             "chemical potential", IchimaruChemPotential()
         )
         plasma_state.update_default_model("BM V_eiS", FiniteWavelength_BM_V())
+        if len(plasma_state) == 1:
+            plasma_state.update_default_model("BM S_ii", Sum_Sii())
+        else:
+            plasma_state.update_default_model("BM S_ii", AverageAtom_Sii())
 
     @jax.jit
     def evaluate_raw(

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -937,6 +937,8 @@ class DebyeWallerSolid(IonFeatModel):
 
     This function uses the :py:class:`jaxrts.plasmastate.PlasmaState` ``'Debye
     temperature'`` model to calculate the Debye Waller factor.
+    Hence, it requires a 'Debye temperature' model (defaults to
+    :py:class:`~BohmStaver`).
 
     See Also
     --------
@@ -966,6 +968,11 @@ class DebyeWallerSolid(IonFeatModel):
         self.S_plasma = S_plasma
         self.b = b
         super().__init__()
+
+
+    def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
+        super().prepare(plasma_state, key)
+        plasma_state.update_default_model("Debye temperature", BohmStaver())
 
     @jax.jit
     def S_ii(self, plasma_state: "PlasmaState", setup: Setup) -> jnp.ndarray:

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1984,10 +1984,13 @@ class SchumacherImpulseFitRk(ScatteringModel):
     Note, that this implementation is still experimental.
 
     Requires a 'form-factors' model (defaults to
-    :py:class:`~PaulingFormFactors`).
+    :py:class:`~.PaulingFormFactors`).
 
     Requires an 'ipd' model (defaults to
-    :py:class:`~Neglect`).
+    :py:class:`~.Neglect`).
+    j
+    Requires a 'free-free scattering' model (defaults to
+    :py:class:`~.RPA_DandreaFit`).
     """
 
     allowed_keys = ["bound-free scattering"]
@@ -1999,6 +2002,9 @@ class SchumacherImpulseFitRk(ScatteringModel):
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         plasma_state.update_default_model("form-factors", PaulingFormFactors())
         plasma_state.update_default_model("ipd", Neglect())
+        plasma_state.update_default_model(
+            "free-free scattering", RPA_DandreaFit()
+        )
 
     @jax.jit
     def r_k(

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -969,7 +969,6 @@ class DebyeWallerSolid(IonFeatModel):
         self.b = b
         super().__init__()
 
-
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         super().prepare(plasma_state, key)
         plasma_state.update_default_model("Debye temperature", BohmStaver())
@@ -2985,6 +2984,11 @@ class Sum_Sii(Model):
     allowed_keys = ["BM S_ii"]
     __name__ = "Sum_Sii"
 
+    def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
+        plasma_state.update_default_model(
+            "ionic scattering", OnePotentialHNCIonFeat()
+        )
+
     def evaluate(
         self,
         plasma_state: "PlasmaState",
@@ -3044,6 +3048,9 @@ class AverageAtom_Sii(Model):
             "ion-ion Potential", hnc_potentials.DebyeHueckelPotential()
         )
         plasma_state["ion-ion Potential"].include_electrons = "off"
+        plasma_state.update_default_model(
+            "ionic scattering", OnePotentialHNCIonFeat()
+        )
 
     @property
     def r(self):

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -2900,7 +2900,7 @@ class ElectronicLFCConstant(Model):
     """
 
     allowed_keys = ["ee-lfc"]
-    __name__ = "None"
+    __name__ = "ElectronicLFCConstant"
 
     def __init__(self, value):
         self.value = value

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -2594,11 +2594,12 @@ class LinearResponseScreeningGericke2010(Model):
         Vei = plasma_state["electron-ion Potential"].full_k(
             plasma_state, to_array(setup.k)[jnp.newaxis]
         )
-        q = xi * Vei[-1, :-1]
+        q = (xi * Vei[-1, :-1]).to(ureg.dimensionless)
         # Screening vanishes if there are no free electrons
         q = jax.lax.cond(
             jnp.sum(plasma_state.Z_free) == 0,
-            lambda: jnp.zeros(len(plasma_state.n_i))[:, jnp.newaxis],
+            lambda: jnp.zeros(len(plasma_state.n_i))[:, jnp.newaxis]
+            * ureg.dimensionless,
             lambda: q,
         )
         return q

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -2675,7 +2675,7 @@ class DebyeHueckelScreening(Model):
 
         kappa = 1 / plasma_state.screening_length
         q = ion_feature.q_DebyeHueckelChapman2015(
-            setup.k,
+            setup.k[jnp.newaxis],
             kappa,
             plasma_state.Z_free,
         )

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -2701,7 +2701,8 @@ class LinearResponseScreening(Model):
     :py:class:`~KlimontovichKraeftPotential`).
 
     Uses the :py:meth:`~.FreeFreeModel.susceptibility` method of the chosen
-    Free Free model.
+    Free Free model. If not free-free model is specified, set the default to
+    :py:class:`~.RPA_DandreaFit`.
     """
 
     allowed_keys = ["screening"]
@@ -2715,6 +2716,7 @@ class LinearResponseScreening(Model):
         plasma_state["electron-ion Potential"].include_electrons = (
             "SpinAveraged"
         )
+        plasma_state["free-free scattering"] = RPA_DandreaFit()
 
     @jax.jit
     def evaluate(

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -2671,7 +2671,7 @@ class DebyeHueckelScreening(Model):
         q = ion_feature.q_DebyeHueckelChapman2015(
             setup.k,
             kappa,
-            plasma_state.Z_f,
+            plasma_state.Z_free,
         )
         q = jnp.real(q.m_as(ureg.dimensionless))
         # Screening vanishes if there are no free electrons

--- a/src/jaxrts/static_structure_factors.py
+++ b/src/jaxrts/static_structure_factors.py
@@ -728,6 +728,6 @@ def debyeWallerFactor(
     TwoM = (
         (3 * ureg.planck_constant**2 * ureg.N_A * Q**2)
         / (atomic_mass * ureg.k_B * debye_temp)
-        * (temp / debye_temp * phi(debye_temp / temp) + 1 / 4)
+        * (temp / jnpu.mean(debye_temp) * phi(jnpu.mean(debye_temp) / temp) + 1 / 4)
     )
     return jnpu.exp(-TwoM).m_as(ureg.dimensionless)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,8 +30,8 @@ for module in [jaxrts.models]:
 available_model_keys = all_models.keys()
 
 
-def _identity(x):
-    return (x / (1 / ureg.angstrom)).m_as(ureg.dimensionless)
+def _peak_function(x):
+    return jnp.array([[1.2]]) * ureg.dimensionless
 
 
 # Some models require additional parameters. Set them.
@@ -61,13 +61,13 @@ def additional_model_parameters(
         return (
             jnp.array([1, 2]) / (1 * ureg.angstrom),
             jnp.array([1, 1]),
-            _identity,
+            _peak_function,
         )
     if model == jaxrts.models.DebyeWallerSolid:
         PowderModel = jaxrts.models.PeakCollection(
             jnp.array([1, 2]) / (1 * ureg.angstrom),
             jnp.array([1, 1]),
-            _identity,
+            _peak_function,
         )
         S_plasmaModel = jaxrts.models.FixedSii(
             jnp.array([[1]]) * ureg.dimensionless

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,7 +53,9 @@ def additional_model_parameters(
     if model == jaxrts.models.ElectronicLFCConstant:
         return (1.2,)
     if model == jaxrts.models.FixedSii:
-        return (jnp.ones((no_of_ions, no_of_ions)) * 1.23,)
+        return (
+            jnp.ones((no_of_ions, no_of_ions)) * 1.23 * ureg.dimensionless,
+        )
 
     if model == jaxrts.models.PeakCollection:
         return (
@@ -67,7 +69,9 @@ def additional_model_parameters(
             jnp.array([1, 1]),
             _identity,
         )
-        S_plasmaModel = jaxrts.models.FixedSii(jnp.array([[1]]))
+        S_plasmaModel = jaxrts.models.FixedSii(
+            jnp.array([[1]]) * ureg.dimensionless
+        )
         return (
             S_plasmaModel,
             PowderModel,
@@ -145,7 +149,9 @@ def test_all_models_can_be_evaluated_one_component():
                 one_comp_test_state = jaxrts.PlasmaState(
                     ions=[jaxrts.Element("C")],
                     Z_free=jnp.array([2]),
-                    mass_density=jnp.array([3.5]) * ureg.gram / ureg.centimeter**3,
+                    mass_density=jnp.array([3.5])
+                    * ureg.gram
+                    / ureg.centimeter**3,
                     T_e=jnp.array([80]) * ureg.electron_volt / ureg.k_B,
                 )
                 one_comp_test_state[key] = model(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
 import copy
+import logging
+from collections import defaultdict
 
 import pytest
 from jax import numpy as jnp
@@ -6,6 +8,75 @@ from jax import numpy as jnp
 import jaxrts
 
 ureg = jaxrts.ureg
+
+
+# Get a list of all models defined within jaxrts
+all_models = defaultdict(list)
+
+for module in [jaxrts.models]:
+    for obj_name in dir(module):
+        if "__class__" in dir(obj_name):
+            attributes = getattr(module, obj_name)
+            if "allowed_keys" in dir(attributes):
+                keys = getattr(attributes, "allowed_keys")
+                if (
+                    ("Model" not in obj_name)
+                    & ("model" not in obj_name)
+                    & (not obj_name.startswith("_"))
+                ):
+                    for k in keys:
+                        all_models[k].append(getattr(module, obj_name))
+
+available_model_keys = all_models.keys()
+
+
+def _identity(x):
+    return (x / (1 / ureg.angstrom)).m_as(ureg.dimensionless)
+
+
+# Some models require additional parameters. Set them.
+def additional_model_parameters(
+    model: jaxrts.models.Model,
+    no_of_ions: int,
+) -> tuple:
+    """
+    Define possible additional parameters for Models
+    """
+    if model == jaxrts.models.ConstantChemPotential:
+        return (123.45 * ureg.electron_volt,)
+    if model == jaxrts.models.ConstantDebyeTemp:
+        return (314.1 * ureg.kelvin,)
+    if model == jaxrts.models.ConstantScreeningLength:
+        return (12.1 * ureg.angstrom,)
+    if model == jaxrts.models.ConstantIPD:
+        return (23.42 * ureg.electron_volt,)
+    if model == jaxrts.models.ElectronicLFCConstant:
+        return (1.2,)
+    if model == jaxrts.models.FixedSii:
+        return (jnp.ones((no_of_ions, no_of_ions)) * 1.23,)
+
+    if model == jaxrts.models.PeakCollection:
+        return (
+            jnp.array([1, 2]) / (1 * ureg.angstrom),
+            jnp.array([1, 1]),
+            _identity,
+        )
+    if model == jaxrts.models.DebyeWallerSolid:
+        PowderModel = jaxrts.models.PeakCollection(
+            jnp.array([1, 2]) / (1 * ureg.angstrom),
+            jnp.array([1, 1]),
+            _identity,
+        )
+        S_plasmaModel = jaxrts.models.FixedSii(jnp.array([[1]]))
+        return (
+            S_plasmaModel,
+            PowderModel,
+        )
+    return ()
+
+
+# You will encounter many warnings about setting defaults. This is fine, here.
+logging.getLogger("jaxrts").setLevel(logging.ERROR)
 
 test_state = jaxrts.PlasmaState(
     ions=[jaxrts.Element("C")],
@@ -65,3 +136,19 @@ def test_ModelEquality():
     # Now change the copy
     model.sample_points = 8
     assert test_state["free-free scattering"] != model
+
+
+def test_all_models_can_be_evaluated_one_component():
+    for key in available_model_keys:
+        for model in all_models[key]:
+            one_comp_test_state = jaxrts.PlasmaState(
+                ions=[jaxrts.Element("C")],
+                Z_free=jnp.array([2]),
+                mass_density=jnp.array([3.5]) * ureg.gram / ureg.centimeter**3,
+                T_e=jnp.array([80]) * ureg.electron_volt / ureg.k_B,
+            )
+            one_comp_test_state[key] = model(
+                *additional_model_parameters(model, 1)
+            )
+            out = one_comp_test_state.evaluate(key, test_setup)
+            assert out is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -141,14 +141,17 @@ def test_ModelEquality():
 def test_all_models_can_be_evaluated_one_component():
     for key in available_model_keys:
         for model in all_models[key]:
-            one_comp_test_state = jaxrts.PlasmaState(
-                ions=[jaxrts.Element("C")],
-                Z_free=jnp.array([2]),
-                mass_density=jnp.array([3.5]) * ureg.gram / ureg.centimeter**3,
-                T_e=jnp.array([80]) * ureg.electron_volt / ureg.k_B,
-            )
-            one_comp_test_state[key] = model(
-                *additional_model_parameters(model, 1)
-            )
-            out = one_comp_test_state.evaluate(key, test_setup)
-            assert out is not None
+            try:
+                one_comp_test_state = jaxrts.PlasmaState(
+                    ions=[jaxrts.Element("C")],
+                    Z_free=jnp.array([2]),
+                    mass_density=jnp.array([3.5]) * ureg.gram / ureg.centimeter**3,
+                    T_e=jnp.array([80]) * ureg.electron_volt / ureg.k_B,
+                )
+                one_comp_test_state[key] = model(
+                    *additional_model_parameters(model, 1)
+                )
+                out = one_comp_test_state.evaluate(key, test_setup)
+                assert out is not None
+            except:
+                raise AssertionError(f"Error evaluating {model} as {key}.")

--- a/tests/test_plasma_state.py
+++ b/tests/test_plasma_state.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 
 from jax import numpy as jnp
 
@@ -16,7 +15,6 @@ test_state = jaxrts.PlasmaState(
 
 
 def test_PlasmaStateEquality():
-    logging.warning(test_state.models.keys())
     # Test comparison with some random type
     assert test_state != 6
     # Test comparison with it's copy


### PR DESCRIPTION
Adds two tests that check that all Models can be evaluated with a plasma with one ion species, and all but those which are not explicitly stated otherwise with a two-ion plasma.

Includes several fixes found that way (all old checks still run).

Note that it only checks that the evaluation does not fail, it is **not** checking the results!
E.g., this PR does include a fix for the units in the EckerKroell IPD model (8cde505) but this is not tested against literature data.

Most of the fixes consist of setting default models to the PlasmaState. This was identified as the preferred behavior to have less friction for a user.