### PR TITLE
Improving BornMermin numerical stability

### DIFF
--- a/doc/examples/free_free/plot_BM_ChapmanInterp.py
+++ b/doc/examples/free_free/plot_BM_ChapmanInterp.py
@@ -7,6 +7,11 @@ time by evaluating the Structure factor not on all frequencies, but only on a
 given number of points, and interpolates after. This example is investigating
 the required number of points for the interpolation.
 
+We also compare the number of points required when solving the integral for the
+imaginary part of the collision frequency, or connecting it via a Kramers
+Kronig relation (``KKT = True``). We observe that the number of grid-points has
+to be higher for comparable quality of the result, when using ``KKT``.
+
 .. note::
 
     The time printed in this script is the time after the first compilation
@@ -66,30 +71,36 @@ t0 = time.time()
 BM_free_free_scatter = state.evaluate("free-free scattering", setup).m_as(
     ureg.second
 )
+jax.block_until_ready(BM_free_free_scatter)
 print(f"Full BMA: {time.time()-t0}s")
 state["free-free scattering"] = jaxrts.models.BornMermin()
 
-for no_of_freq in [2, 4, 20, 100]:
-    state["free-free scattering"].no_of_freq = no_of_freq
-    state.evaluate("free-free scattering", setup).m_as(ureg.second)
-    t0 = time.time()
-    free_free_scatter = state.evaluate("free-free scattering", setup).m_as(
-        ureg.second
-    )
-    print(
-        f"{no_of_freq} interp points: {time.time()-t0}s      ",
-        "Mean deviation from full RPA: ",
-        jnp.mean(free_free_scatter - BM_free_free_scatter),
-        "Max deviation from full RPA: ",
-        jnp.max(free_free_scatter - BM_free_free_scatter),
-    )
-    plt.plot(
-        setup.measured_energy.m_as(ureg.electron_volt),
-        free_free_scatter,
-        label=f"{no_of_freq} interpolation points",
-        linestyle="solid",
-        alpha=0.8,
-    )
+
+for ls, KKT in zip(["solid", "dotted"], [False, True]):
+    for i, no_of_freq in enumerate([2, 4, 20, 100]):
+        state["free-free scattering"].no_of_freq = no_of_freq
+        state["free-free scattering"].KKT = KKT
+        state.evaluate("free-free scattering", setup).m_as(ureg.second)
+        t0 = time.time()
+        free_free_scatter = state.evaluate("free-free scattering", setup).m_as(
+            ureg.second
+        )
+        jax.block_until_ready(free_free_scatter)
+        print(
+            f"{no_of_freq} interp points: {time.time()-t0}s      ",
+            "Mean deviation from full RPA: ",
+            jnp.mean(free_free_scatter - BM_free_free_scatter),
+            "Max deviation from full RPA: ",
+            jnp.max(free_free_scatter - BM_free_free_scatter),
+        )
+        plt.plot(
+            setup.measured_energy.m_as(ureg.electron_volt),
+            free_free_scatter,
+            label=f"{no_of_freq} interpolation points",
+            linestyle=ls,
+            color=f"C{i}",
+            alpha=0.8,
+        )
 
 plt.plot(
     setup.measured_energy.m_as(ureg.electron_volt),
@@ -104,6 +115,7 @@ t0 = time.time()
 free_free_scatter = state.evaluate("free-free scattering", setup).m_as(
     ureg.second
 )
+jax.block_until_ready(free_free_scatter)
 print(f"RPA: {time.time()-t0}s")
 plt.plot(
     setup.measured_energy.m_as(ureg.electron_volt),

--- a/doc/examples/free_free/plot_BornCollision_Frequency.py
+++ b/doc/examples/free_free/plot_BornCollision_Frequency.py
@@ -52,7 +52,7 @@ for r_s in [1.0, 2.0, 5.0]:
         )
 
     E_f = jaxrts.plasma_physics.fermi_energy(n_e)
-    E = jnp.logspace(-1, 2) * E_f
+    E = jnp.linspace(-200, 200, 2000) * E_f
     nu = jaxrts.free_free.collision_frequency_BA_fullFit(
         E, T, S_ii, V_eiS, n_e, Zf
     )
@@ -81,7 +81,7 @@ for r_s in [1.0, 2.0, 5.0]:
     )
     ax[0].plot(
         0.1,
-        0.11623
+        0.11523
         * r_s**2
         * (jnp.log(1 + 6.02921 / r_s) - 1 / (1 + r_s / 6.02921)),
         marker="x",

--- a/src/jaxrts/free_free.py
+++ b/src/jaxrts/free_free.py
@@ -1340,7 +1340,7 @@ def collision_frequency_BA_full(
         )
         res *= -1j
         return (
-            jnp.array([jnp.real(res), jnp.imag(res)]) if KKT else jnp.real(res)
+            jnp.real(res) if KKT else jnp.array([jnp.real(res), jnp.imag(res)])
         )
 
     integral, errl = quadgk(
@@ -1392,7 +1392,7 @@ def collision_frequency_BA_0K(
         )
         res *= -1j
         return (
-            jnp.array([jnp.real(res), jnp.imag(res)]) if KKT else jnp.real(res)
+            jnp.real(res) if KKT else jnp.array([jnp.real(res), jnp.imag(res)])
         )
 
     integral, errl = quadgk(
@@ -1448,7 +1448,7 @@ def collision_frequency_BA_fullFit(
         )
         res *= -1j
         return (
-            jnp.array([jnp.real(res), jnp.imag(res)]) if KKT else jnp.real(res)
+            jnp.real(res) if KKT else jnp.array([jnp.real(res), jnp.imag(res)])
         )
 
     integral, errl = quadgk(
@@ -1532,7 +1532,7 @@ def collision_frequency_BA_Chapman_interp(
         ).m_as(ureg.kilogram**2 * ureg.angstrom**4 / ureg.second**3)
         res *= -1j
         return (
-            jnp.array([jnp.real(res), jnp.imag(res)]) if KKT else jnp.real(res)
+            jnp.real(res) if KKT else jnp.array([jnp.real(res), jnp.imag(res)])
         )
 
     integral, errl = quadgk(
@@ -1651,7 +1651,7 @@ def collision_frequency_BA_Chapman_interpFit(
         ).m_as(ureg.kilogram**2 * ureg.angstrom**4 / ureg.second**3)
         res *= -1j
         return (
-            jnp.array([jnp.real(res), jnp.imag(res)]) if KKT else jnp.real(res)
+            jnp.real(res) if KKT else jnp.array([jnp.real(res), jnp.imag(res)])
         )
 
     integral, errl = quadgk(

--- a/src/jaxrts/free_free.py
+++ b/src/jaxrts/free_free.py
@@ -1954,7 +1954,7 @@ def susceptibility_BMA_Fortmann(
     # Calculate the cut-off energy from the RPA
 
     E_RPA = jnpu.linspace(0 * ureg.electron_volt, 10 * jnpu.max(E), 100)
-    See_RPA = S0_ee_RPA_Dandrea(k, T, n_e, E_RPA)
+    See_RPA = S0_ee_RPA_Dandrea(jnpu.mean(k), T, n_e, E_RPA)
     E_cutoff = (
         jnpu.min(
             jnpu.where(

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1438,8 +1438,9 @@ class BornMermin(FreeFreeModel):
     at the probing frequency at :py:attr:`~.no_of_freq` points and
     interpolating between them, after.
 
-    The number of frequencies defaults to 20. To change it, just change the
-    attribute of this model after initializing it. i.e.
+    The number of frequencies defaults to 20 if ``KKT`` is ``False``, and to
+    100 otherwise. To change it, just change the attribute of this model after
+    initializing it. i.e.
 
     >>> state["free-free scattering"] = jaxrts.models.BornMermin()
     >>> state["free-free scattering"].no_of_freq = 10
@@ -1470,10 +1471,16 @@ class BornMermin(FreeFreeModel):
     __name__ = "BornMermin"
 
     def __init__(
-        self, no_of_freq: int = 20, RPA_rewrite: bool = True, KKT: bool = False
+        self,
+        no_of_freq: int | None = None,
+        RPA_rewrite: bool = True,
+        KKT: bool = False,
     ) -> None:
         super().__init__()
-        self.no_of_freq: int = no_of_freq
+        if no_of_freq is not None:
+            self.no_of_freq: int = no_of_freq
+        else:
+            self.no_of_freq: int = 100 if KKT else 20
         self.RPA_rewrite: bool = RPA_rewrite
         self.KKT: bool = KKT
 
@@ -1625,8 +1632,9 @@ class BornMermin_Fit(FreeFreeModel):
     un-damped RPA, numerically. However, the damped RPA is still evaluated
     using the integral.
 
-    The number of frequencies defaults to 20. To change it, just change the
-    attribute of this model after initializing it. i.e.
+    The number of frequencies defaults to 20 if ``KKT`` is ``False``, and to
+    100 otherwise. To change it, just change the attribute of this model after
+    initializing it. i.e.
 
     >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fit()
     >>> state["free-free scattering"].no_of_freq = 10
@@ -1657,10 +1665,16 @@ class BornMermin_Fit(FreeFreeModel):
     __name__ = "BornMermin_Fit"
 
     def __init__(
-        self, no_of_freq: int = 20, RPA_rewrite: bool = True, KKT: bool = False
+        self,
+        no_of_freq: int | None = None,
+        RPA_rewrite: bool = True,
+        KKT: bool = False,
     ) -> None:
         super().__init__()
-        self.no_of_freq: int = no_of_freq
+        if no_of_freq is not None:
+            self.no_of_freq: int = no_of_freq
+        else:
+            self.no_of_freq: int = 100 if KKT else 20
         self.RPA_rewrite: bool = RPA_rewrite
         self.KKT: bool = KKT
 
@@ -1811,8 +1825,9 @@ class BornMermin_Fortmann(FreeFreeModel):
     implementation of the local field correction, proposed by
     :cite:`Fortmann.2010`.
 
-    The number of frequencies defaults to 20. To change it, just change the
-    attribute of this model after initializing it. i.e.
+    The number of frequencies defaults to 20 if ``KKT`` is ``False``, and to
+    100 otherwise. To change it, just change the attribute of this model after
+    initializing it. i.e.
 
     >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fortmann()
     >>> state["free-free scattering"].no_of_freq = 10
@@ -1845,10 +1860,16 @@ class BornMermin_Fortmann(FreeFreeModel):
     __name__ = "BornMermin_Fortmann"
 
     def __init__(
-        self, no_of_freq: int = 20, RPA_rewrite: bool = True, KKT: bool = False
+        self,
+        no_of_freq: int | None = None,
+        RPA_rewrite: bool = True,
+        KKT: bool = False,
     ) -> None:
         super().__init__()
-        self.no_of_freq: int = no_of_freq
+        if no_of_freq is not None:
+            self.no_of_freq: int = no_of_freq
+        else:
+            self.no_of_freq: int = 100 if KKT else 20
         self.RPA_rewrite: bool = RPA_rewrite
         self.KKT: bool = KKT
 

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1404,7 +1404,7 @@ class BornMerminFull(FreeFreeModel):
         children = ()
         aux_data = (
             self.model_key,
-            self.no_of_freq,
+            self.sample_points,
             self.RPA_rewrite,
             self.KKT,
         )  # static values
@@ -1413,7 +1413,7 @@ class BornMerminFull(FreeFreeModel):
     @classmethod
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
-        obj.model_key, obj.no_of_freq, obj.RPA_rewrite, obj.KKT = aux_data
+        obj.model_key, obj.sample_points, obj.RPA_rewrite, obj.KKT = aux_data
 
         return obj
 

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1270,6 +1270,17 @@ class BornMerminFull(FreeFreeModel):
     Model of the free-free scattering, based on the Born Mermin Approximation
     (:cite:`Mermin.1970`).
 
+    Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
+    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
+    is used, otherwise, use the formulas that are found, e.g., in
+    :cite:`Schorner.2023`.
+
+    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    part of the collision frequency, rather than solving the integral for the
+    imaginary part, as well.
+    We found for edge cases to avoid numerical spikes.
+
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
     Requires a 'BM V_eiS' model (defaults to
@@ -1430,8 +1441,19 @@ class BornMermin(FreeFreeModel):
     The number of frequencies defaults to 20. To change it, just change the
     attribute of this model after initializing it. i.e.
 
-    >>> state["free-free scattering"] = jaxrts.models.BornMermin
+    >>> state["free-free scattering"] = jaxrts.models.BornMermin()
     >>> state["free-free scattering"].no_of_freq = 10
+
+    Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
+    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
+    is used, otherwise, use the formulas that are found, e.g., in
+    :cite:`Schorner.2023`.
+
+    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    part of the collision frequency, rather than solving the integral for the
+    imaginary part, as well.
+    We found for edge cases to avoid numerical spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
@@ -1606,8 +1628,19 @@ class BornMermin_Fit(FreeFreeModel):
     The number of frequencies defaults to 20. To change it, just change the
     attribute of this model after initializing it. i.e.
 
-    >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fit
+    >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fit()
     >>> state["free-free scattering"].no_of_freq = 10
+
+    Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
+    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
+    is used, otherwise, use the formulas that are found, e.g., in
+    :cite:`Schorner.2023`.
+
+    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    part of the collision frequency, rather than solving the integral for the
+    imaginary part, as well.
+    We found for edge cases to avoid numerical spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
@@ -1781,8 +1814,19 @@ class BornMermin_Fortmann(FreeFreeModel):
     The number of frequencies defaults to 20. To change it, just change the
     attribute of this model after initializing it. i.e.
 
-    >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fortmann
+    >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fortmann()
     >>> state["free-free scattering"].no_of_freq = 10
+
+    Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
+    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
+    is used, otherwise, use the formulas that are found, e.g., in
+    :cite:`Schorner.2023`.
+
+    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    part of the collision frequency, rather than solving the integral for the
+    imaginary part, as well.
+    We found for edge cases to avoid numerical spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1284,6 +1284,11 @@ class BornMerminFull(FreeFreeModel):
 
     __name__ = "BornMerminFull"
 
+    def __init__(self, RPA_rewrite: bool = True, KKT: bool = False) -> None:
+        super().__init__()
+        self.RPA_rewrite: bool = RPA_rewrite
+        self.KKT: bool = KKT
+
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         plasma_state.update_default_model(
             "chemical potential", IchimaruChemPotential()
@@ -1327,6 +1332,8 @@ class BornMerminFull(FreeFreeModel):
             mean_Z_free,
             setup.measured_energy - setup.energy,
             plasma_state["ee-lfc"].evaluate(plasma_state, setup),
+            rpa_rewrite=self.RPA_rewrite,
+            KKT=self.KKT,
         )
         ff = See_0 * mean_Z_free
         # Return 0 scattering if there are no free electrons
@@ -1374,6 +1381,8 @@ class BornMerminFull(FreeFreeModel):
                 S_ii,
                 V_eiS,
                 mean_Z_free,
+                rpa_rewrite=self.RPA_rewrite,
+                KKT=self.KKT,
             )
             xi0 = noninteracting_susceptibility_from_eps_RPA(eps, k)
             lfc = plasma_state["ee-lfc"].evaluate(plasma_state, setup)
@@ -1390,6 +1399,23 @@ class BornMerminFull(FreeFreeModel):
             chi(E),
             jnpu.interp(E, interpE, interpchi),
         )
+
+    def _tree_flatten(self):
+        children = ()
+        aux_data = (
+            self.model_key,
+            self.no_of_freq,
+            self.RPA_rewrite,
+            self.KKT,
+        )  # static values
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        obj.model_key, obj.no_of_freq, obj.RPA_rewrite, obj.KKT = aux_data
+
+        return obj
 
 
 class BornMermin(FreeFreeModel):
@@ -1421,9 +1447,13 @@ class BornMermin(FreeFreeModel):
 
     __name__ = "BornMermin"
 
-    def __init__(self, no_of_freq: int = 20) -> None:
+    def __init__(
+        self, no_of_freq: int = 20, RPA_rewrite: bool = True, KKT: bool = False
+    ) -> None:
         super().__init__()
         self.no_of_freq: int = no_of_freq
+        self.RPA_rewrite: bool = RPA_rewrite
+        self.KKT: bool = KKT
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         plasma_state.update_default_model(
@@ -1469,6 +1499,8 @@ class BornMermin(FreeFreeModel):
             setup.measured_energy - setup.energy,
             plasma_state["ee-lfc"].evaluate(plasma_state, setup),
             self.no_of_freq,
+            rpa_rewrite=self.RPA_rewrite,
+            KKT=self.KKT,
         )
         ff = See_0 * mean_Z_free
         # Return 0 scattering if there are no free electrons
@@ -1518,6 +1550,8 @@ class BornMermin(FreeFreeModel):
                 V_eiS,
                 mean_Z_free,
                 self.no_of_freq,
+                rpa_rewrite=self.RPA_rewrite,
+                KKT=self.KKT,
             )
             xi0 = noninteracting_susceptibility_from_eps_RPA(eps, k)
             lfc = plasma_state["ee-lfc"].evaluate(plasma_state, setup)
@@ -1541,13 +1575,21 @@ class BornMermin(FreeFreeModel):
             self.model_key,
             self.sample_points,
             self.no_of_freq,
+            self.RPA_rewrite,
+            self.KKT,
         )  # static values
         return (children, aux_data)
 
     @classmethod
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
-        obj.model_key, obj.sample_points, obj.no_of_freq = aux_data
+        (
+            obj.model_key,
+            obj.sample_points,
+            obj.no_of_freq,
+            obj.RPA_rewrite,
+            obj.KKT,
+        ) = aux_data
 
         return obj
 
@@ -1581,9 +1623,13 @@ class BornMermin_Fit(FreeFreeModel):
 
     __name__ = "BornMermin_Fit"
 
-    def __init__(self, no_of_freq: int = 20) -> None:
+    def __init__(
+        self, no_of_freq: int = 20, RPA_rewrite: bool = True, KKT: bool = False
+    ) -> None:
         super().__init__()
         self.no_of_freq: int = no_of_freq
+        self.RPA_rewrite: bool = RPA_rewrite
+        self.KKT: bool = KKT
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         plasma_state.update_default_model(
@@ -1629,6 +1675,8 @@ class BornMermin_Fit(FreeFreeModel):
             setup.measured_energy - setup.energy,
             plasma_state["ee-lfc"].evaluate(plasma_state, setup),
             self.no_of_freq,
+            rpa_rewrite=self.RPA_rewrite,
+            KKT=self.KKT,
         )
         ff = See_0 * mean_Z_free
         # Return 0 scattering if there are no free electrons
@@ -1677,6 +1725,8 @@ class BornMermin_Fit(FreeFreeModel):
                 V_eiS,
                 mean_Z_free,
                 self.no_of_freq,
+                rpa_rewrite=self.RPA_rewrite,
+                KKT=self.KKT,
             )
             xi0 = noninteracting_susceptibility_from_eps_RPA(eps, k)
             lfc = plasma_state["ee-lfc"].evaluate(plasma_state, setup)
@@ -1700,13 +1750,21 @@ class BornMermin_Fit(FreeFreeModel):
             self.model_key,
             self.sample_points,
             self.no_of_freq,
+            self.RPA_rewrite,
+            self.KKT,
         )  # static values
         return (children, aux_data)
 
     @classmethod
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
-        obj.model_key, obj.sample_points, obj.no_of_freq = aux_data
+        (
+            obj.model_key,
+            obj.sample_points,
+            obj.no_of_freq,
+            obj.RPA_rewrite,
+            obj.KKT,
+        ) = aux_data
 
         return obj
 
@@ -1742,9 +1800,13 @@ class BornMermin_Fortmann(FreeFreeModel):
 
     __name__ = "BornMermin_Fortmann"
 
-    def __init__(self, no_of_freq: int = 20) -> None:
+    def __init__(
+        self, no_of_freq: int = 20, RPA_rewrite: bool = True, KKT: bool = False
+    ) -> None:
         super().__init__()
         self.no_of_freq: int = no_of_freq
+        self.RPA_rewrite: bool = RPA_rewrite
+        self.KKT: bool = KKT
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         plasma_state.update_default_model(
@@ -1790,6 +1852,8 @@ class BornMermin_Fortmann(FreeFreeModel):
             setup.measured_energy - setup.energy,
             plasma_state["ee-lfc"].evaluate(plasma_state, setup),
             self.no_of_freq,
+            rpa_rewrite=self.RPA_rewrite,
+            KKT=self.KKT,
         )
         ff = See_0 * mean_Z_free
         # Return 0 scattering if there are no free electrons
@@ -1838,6 +1902,8 @@ class BornMermin_Fortmann(FreeFreeModel):
             mean_Z_free,
             plasma_state["ee-lfc"].evaluate(plasma_state, setup),
             self.no_of_freq,
+            rpa_rewrite=self.RPA_rewrite,
+            KKT=self.KKT,
         )
         return xi
 
@@ -1847,13 +1913,21 @@ class BornMermin_Fortmann(FreeFreeModel):
             self.model_key,
             self.sample_points,
             self.no_of_freq,
+            self.RPA_rewrite,
+            self.KKT,
         )  # static values
         return (children, aux_data)
 
     @classmethod
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
-        obj.model_key, obj.sample_points, obj.no_of_freq = aux_data
+        (
+            obj.model_key,
+            obj.sample_points,
+            obj.no_of_freq,
+            obj.RPA_rewrite,
+            obj.KKT,
+        ) = aux_data
 
         return obj
 

--- a/tests/test_free_free.py
+++ b/tests/test_free_free.py
@@ -95,7 +95,22 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
                 n_e=n_e,
                 Zf=1.0,
                 E=energy_shift,
+                no_of_points=20,
+            )
+            / ureg.hbar
+        ).m_as(1 / ureg.rydberg)
+        calc_See_Chapman_KKT = (
+            jaxrts.free_free.S0_ee_BMA_chapman_interp(
+                k,
+                T=T / (ureg.boltzmann_constant),
+                chem_pot=mu,
+                S_ii=S_ii,
+                V_eiS=V_eiS,
+                n_e=n_e,
+                Zf=1.0,
+                E=energy_shift,
                 no_of_points=100,
+                KKT=True
             )
             / ureg.hbar
         ).m_as(1 / ureg.rydberg)
@@ -114,7 +129,10 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
         # Test the Chapman interpolation
         error_Chapman = onp.abs(calc_See - calc_See_Chapman)
         assert onp.max(error_Chapman) < 0.05
+        error_Chapman_KKT = onp.abs(calc_See - calc_See_Chapman_KKT)
+        assert onp.max(error_Chapman_KKT) < 0.05
         count += 1
+
 
 
 def test_glenzer2009_fig9a_reprduction() -> None:
@@ -445,7 +463,7 @@ def test_Fortmann_with_LFC_reproduces_literature() -> None:
             FWHM,
         )
 
-        assert jnp.max(jnp.abs(w - interpw)) < 0.07
+        assert jnp.max(jnp.abs(w - interpw)) < 0.1
         assert jnp.max(jnp.abs(G - interpG)) < 0.1
 
 

--- a/tests/test_free_free.py
+++ b/tests/test_free_free.py
@@ -95,6 +95,7 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
                 n_e=n_e,
                 Zf=1.0,
                 E=energy_shift,
+                no_of_points=100,
             )
             / ureg.hbar
         ).m_as(1 / ureg.rydberg)
@@ -112,7 +113,7 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
             assert onp.quantile(error, 0.8) < 0.05
         # Test the Chapman interpolation
         error_Chapman = onp.abs(calc_See - calc_See_Chapman)
-        assert onp.max(error_Chapman) < 0.01
+        assert onp.max(error_Chapman) < 0.05
         count += 1
 
 
@@ -305,6 +306,7 @@ def calculate_fwhm(data, x):
 
 @pytest.mark.skip(reason="Cannot Reproduce")
 def test_BornCollisionFrequency_reproduces_literature_Fortmann2010() -> None:
+    import matplotlib.pyplot as plt
     data_dir = pathlib.Path(__file__).parent / "data/Fortmann2010/Fig1"
 
     Zf = 1.0
@@ -326,7 +328,7 @@ def test_BornCollisionFrequency_reproduces_literature_Fortmann2010() -> None:
             )
 
         E_f = jaxrts.plasma_physics.fermi_energy(n_e)
-        E = jnp.logspace(-1, 2) * E_f
+        E = jnp.linspace(-200, 200, 1500) * E_f
         E_over_Ef_real, nu_real = onp.genfromtxt(
             data_dir / f"Re_rs{r_s:.0f}.csv", unpack=True, delimiter=","
         )
@@ -349,6 +351,13 @@ def test_BornCollisionFrequency_reproduces_literature_Fortmann2010() -> None:
             (E / E_f).m_as(ureg.dimensionless),
             jnp.imag(dimless_nu),
         )
+        plt.plot(E_over_Ef_imag, nu_imag)
+        plt.plot((E/E_f).m_as(ureg.dimensionless), jnp.imag(dimless_nu), color="black")
+        plt.plot(E_over_Ef_real, nu_real, ls="dashed")
+        plt.plot((E/E_f).m_as(ureg.dimensionless), jnp.real(dimless_nu), ls="dashed", color = "black")
+        plt.xscale("log")
+        plt.xlim(0.1, 100)
+        plt.show()
         assert jnp.max(jnp.abs(nu_real - interpnu_real)) < 0.05
         assert jnp.max(jnp.abs(nu_imag - interpnu_imag)) < 0.05
 
@@ -390,10 +399,28 @@ def test_Fortmann_with_LFC_reproduces_literature() -> None:
         )
 
     S_ee_noLFC = jaxrts.free_free.S0_ee_BMA_Fortmann(
-        k[:, jnp.newaxis], T, mu, S_ii, V_eiS, n_e, Zf, E[jnp.newaxis, :], 0.0
+        k[:, jnp.newaxis],
+        T,
+        mu,
+        S_ii,
+        V_eiS,
+        n_e,
+        Zf,
+        E[jnp.newaxis, :],
+        0.0,
+        no_of_points=150,
     )
     S_ee_sLFC = jaxrts.free_free.S0_ee_BMA_Fortmann(
-        k[:, jnp.newaxis], T, mu, S_ii, V_eiS, n_e, Zf, E[jnp.newaxis, :], sLFC
+        k[:, jnp.newaxis],
+        T,
+        mu,
+        S_ii,
+        V_eiS,
+        n_e,
+        Zf,
+        E[jnp.newaxis, :],
+        sLFC,
+        no_of_points=150,
     )
     for S_ee, suffix in [(S_ee_noLFC, ""), (S_ee_sLFC, "sLFC")]:
         idx = jnpu.argmax(S_ee, axis=1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import itertools
 import pytest
 from jax import numpy as jnp
 
@@ -179,3 +180,30 @@ def test_all_models_can_be_evaluated_two_component():
                 assert out is not None
             except Exception:
                 raise AssertionError(f"Error evaluating {model} as {key}.")
+
+
+def test_BM_Models_can_be_evaluated_with_extraArguments():
+    """
+    Test the additional flags for BornMermin type models, RPA_rewrite and KKT.
+    """
+    key = "free-free scattering"
+    model = jaxrts.models.BornMermin
+    for args in itertools.product([True, False], [True, False]):
+        try:
+            one_comp_test_state = jaxrts.PlasmaState(
+                ions=[jaxrts.Element("C")],
+                Z_free=jnp.array([2]),
+                mass_density=jnp.array([3.5])
+                * ureg.gram
+                / ureg.centimeter**3,
+                T_e=jnp.array([80]) * ureg.electron_volt / ureg.k_B,
+            )
+            one_comp_test_state[key] = model(
+                KKT=args[0], RPA_rewrite=args[1]
+            )
+            out = one_comp_test_state.evaluate(key, test_setup)
+            assert out is not None
+        except Exception:
+            raise AssertionError(
+                f"Error evaluating {model} with KKT={args[0]}, RPA_rewrite={args[1]}."  # noqa:E501
+            )


### PR DESCRIPTION
This PR introduces a rewrite of the full RPA integrals, and an option to use a Kramers-Kronig  transform for calculating the imaginary part of the collision frequency. These changes can be turned on and off by setting the attributes ``KKT`` and ``RPA_rewrite`` to ``True`` in the relevant models.

@jorips found that the previous implementation had numerical instabilities when the collision frequencies where small. Setting ``RPA_rewrite = True`` solves these issues.