### PR TITLE
BM cutoffs

### DIFF
--- a/doc/examples/free_free/plot_BM_ChapmanInterp.py
+++ b/doc/examples/free_free/plot_BM_ChapmanInterp.py
@@ -74,6 +74,7 @@ BM_free_free_scatter = state.evaluate("free-free scattering", setup).m_as(
 jax.block_until_ready(BM_free_free_scatter)
 print(f"Full BMA: {time.time()-t0}s")
 state["free-free scattering"] = jaxrts.models.BornMermin()
+state["free-free scattering"].set_guessed_E_cutoffs(state, setup)
 
 
 for ls, KKT in zip(["solid", "dotted"], [False, True]):

--- a/doc/examples/free_free/plot_Fortmann_BMA.py
+++ b/doc/examples/free_free/plot_Fortmann_BMA.py
@@ -84,11 +84,33 @@ sLFC = jaxrts.ee_localfieldcorrections.eelfc_interpolationgregori_farid(
     k[:, jnp.newaxis], T, n_e
 )
 
+Emin = jnpu.min(jnpu.absolute(E))
+Emax = jnpu.max(jnpu.absolute(E))
 S_ee_noLFC = jaxrts.free_free.S0_ee_BMA_Fortmann(
-    k[:, jnp.newaxis], T, mu, S_ii, V_eiS, n_e, Zf, E[jnp.newaxis, :], 0.0
+    k[:, jnp.newaxis],
+    T,
+    mu,
+    S_ii,
+    V_eiS,
+    n_e,
+    Zf,
+    Emin,
+    Emax,
+    E[jnp.newaxis, :],
+    0.0,
 )
 S_ee_sLFC = jaxrts.free_free.S0_ee_BMA_Fortmann(
-    k[:, jnp.newaxis], T, mu, S_ii, V_eiS, n_e, Zf, E[jnp.newaxis, :], sLFC
+    k[:, jnp.newaxis],
+    T,
+    mu,
+    S_ii,
+    V_eiS,
+    n_e,
+    Zf,
+    Emin,
+    Emax,
+    E[jnp.newaxis, :],
+    sLFC,
 )
 
 plt.style.use("science")

--- a/doc/examples/free_free/plot_See0_RPA_BM.py
+++ b/doc/examples/free_free/plot_See0_RPA_BM.py
@@ -22,6 +22,7 @@ import time
 
 import jax
 import jax.numpy as jnp
+import jpu.numpy as jnpu
 import matplotlib.pyplot as plt
 
 import jaxrts
@@ -112,6 +113,8 @@ for T in [
             S_ii=S_ii,
             V_eiS=V_eiS,
             Zf=1.0,
+            E_cutoff_min = jnpu.min(jnpu.absolute(E)),
+            E_cutoff_max = jnpu.max(jnpu.absolute(E)),
             no_of_points=10,
         )
         / ureg.hbar

--- a/playground/mcss_comp.py
+++ b/playground/mcss_comp.py
@@ -14,9 +14,9 @@ import sys
 
 import jax
 
-jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
-jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
-jax.config.update("jax_persistent_cache_min_compile_time_secs", 0.2)
+# jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
+# jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
+# jax.config.update("jax_persistent_cache_min_compile_time_secs", 0.2)
 
 import os
 import re
@@ -156,7 +156,16 @@ def plot_mcss_comparison(mcss_file):
     if ff.lower() == "dandrea_rpa_fit":
         state["free-free scattering"] = jaxrts.models.RPA_DandreaFit()
     elif ff.lower() == "born_mermin":
-        state["free-free scattering"] = jaxrts.models.BornMermin()
+        state["free-free scattering"] = jaxrts.models.BornMermin(
+            no_of_freq=40, KKT=False, RPA_rewrite=True
+        )
+        state["free-free scattering"].set_guessed_E_cutoffs(state, setup)
+        print(
+            state["free-free scattering"].E_cutoff_min.to(ureg.electron_volt)
+        )
+        print(
+            state["free-free scattering"].E_cutoff_max.to(ureg.electron_volt)
+        )
     state["bound-free scattering"] = jaxrts.models.SchumacherImpulse(r_k=rk)
     state["free-bound scattering"] = jaxrts.models.Neglect()
 
@@ -174,12 +183,13 @@ def plot_mcss_comparison(mcss_file):
 
     I = state.probe(setup)
     t0 = time.time()
-    state.probe(setup)
+    I = state.probe(setup)
+    jax.block_until_ready(I)
     print(f"One sample takes {time.time()-t0}s.")
-    norm = jnpu.max(
-        state.evaluate("free-free scattering", setup)
-        # + state.evaluate("bound-free scattering", setup)
-    )
+    ff = state.evaluate("free-free scattering", setup)
+    bf = state.evaluate("bound-free scattering", setup)
+    el = state.evaluate("ionic scattering", setup)
+    norm = jnpu.max(ff)
 
     fig, ax0 = plt.subplots()
     inset_ax = inset_axes(ax0, width="50%", height="50%", loc="upper left")
@@ -187,15 +197,13 @@ def plot_mcss_comparison(mcss_file):
     for ax in [ax0, inset_ax]:
         ax.plot(
             (setup.measured_energy).m_as(ureg.electron_volt),
-            (I / norm).m_as(ureg.dimensionless),
-            color="C0",
+            ((bf + ff + el) / norm).m_as(ureg.dimensionless),
+            color="black",
             label="JaXRTS",
         )
         ax.plot(
             (setup.measured_energy).m_as(ureg.electron_volt),
-            (state.evaluate("bound-free scattering", setup) / norm).m_as(
-                ureg.dimensionless
-            ),
+            (bf / norm).m_as(ureg.dimensionless),
             color="C0",
             ls="dashed",
             label="JaXRTS, bf",
@@ -203,9 +211,7 @@ def plot_mcss_comparison(mcss_file):
         )
         ax.plot(
             (setup.measured_energy).m_as(ureg.electron_volt),
-            (state.evaluate("free-free scattering", setup) / norm).m_as(
-                ureg.dimensionless
-            ),
+            (ff / norm).m_as(ureg.dimensionless),
             color="C0",
             ls="dotted",
             label="JaXRTS, ff",
@@ -213,13 +219,17 @@ def plot_mcss_comparison(mcss_file):
         )
         ax.plot(
             (setup.measured_energy).m_as(ureg.electron_volt),
-            (state.evaluate("ionic scattering", setup) / norm).m_as(
-                ureg.dimensionless
-            ),
+            (el / norm).m_as(ureg.dimensionless),
             color="C0",
             ls="dashdot",
             label="JaXRTS, elastic",
             alpha=0.7,
+        )
+        ax.plot(
+            (setup.measured_energy).m_as(ureg.electron_volt),
+            (I / norm).m_as(ureg.dimensionless),
+            color="C0",
+            label="JaXRTS",
         )
         MCSS_Norm = jnp.max(S_ff)
         ax.plot(
@@ -261,7 +271,9 @@ def plot_mcss_comparison(mcss_file):
     plt.close()
 
 
-for mcss_file in (file_dir / "../tests/mcss_samples").glob("mcss*.txt"):
+for mcss_file in sorted(
+    list((file_dir / "../tests/mcss_samples").glob("mcss*.txt"))
+):
     print(mcss_file)
     plot_mcss_comparison(mcss_file)
 

--- a/src/jaxrts/free_free.py
+++ b/src/jaxrts/free_free.py
@@ -1234,7 +1234,7 @@ def S0_ee_RPA(
         The chemical potential in units of energy.
     rpa_rewrite: bool, default ``True``
         Use the rewrite of the RPA dielectric function from
-        :cite:`Chapman.2015`, rather than :cite:`Schoerner.2023`.
+        :cite:`Chapman.2015`, rather than :cite:`Schorner.2023`.
 
     Returns
     -------

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -1276,7 +1276,7 @@ class BornMerminFull(FreeFreeModel):
     :cite:`Schorner.2023`.
 
     Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
-    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
     We found for edge cases to avoid numerical spikes.
@@ -1460,7 +1460,7 @@ class BornMermin(FreeFreeModel):
     :cite:`Schorner.2023`.
 
     Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
-    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
     We found for edge cases to avoid numerical spikes.
@@ -1729,7 +1729,7 @@ class BornMermin_Fit(FreeFreeModel):
     :cite:`Schorner.2023`.
 
     Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
-    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
     We found for edge cases to avoid numerical spikes.
@@ -1997,7 +1997,7 @@ class BornMermin_Fortmann(FreeFreeModel):
     :cite:`Schorner.2023`.
 
     Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
-    using :cite:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
+    using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
     We found for edge cases to avoid numerical spikes.

--- a/tests/test_free_free.py
+++ b/tests/test_free_free.py
@@ -94,6 +94,8 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
                 V_eiS=V_eiS,
                 n_e=n_e,
                 Zf=1.0,
+                E_cutoff_min=jnpu.min(jnpu.absolute(energy_shift)),
+                E_cutoff_max=jnpu.max(jnpu.absolute(energy_shift)),
                 E=energy_shift,
                 no_of_points=20,
             )
@@ -109,8 +111,10 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
                 n_e=n_e,
                 Zf=1.0,
                 E=energy_shift,
+                E_cutoff_min=1 / 2 * jnpu.min(jnpu.absolute(energy_shift)),
+                E_cutoff_max=10 * jnpu.max(jnpu.absolute(energy_shift)),
                 no_of_points=100,
-                KKT=True
+                KKT=True,
             )
             / ureg.hbar
         ).m_as(1 / ureg.rydberg)
@@ -132,7 +136,6 @@ def test_BM_glenzer2009_fig9b_reprduction() -> None:
         error_Chapman_KKT = onp.abs(calc_See - calc_See_Chapman_KKT)
         assert onp.max(error_Chapman_KKT) < 0.05
         count += 1
-
 
 
 def test_glenzer2009_fig9a_reprduction() -> None:
@@ -325,6 +328,7 @@ def calculate_fwhm(data, x):
 @pytest.mark.skip(reason="Cannot Reproduce")
 def test_BornCollisionFrequency_reproduces_literature_Fortmann2010() -> None:
     import matplotlib.pyplot as plt
+
     data_dir = pathlib.Path(__file__).parent / "data/Fortmann2010/Fig1"
 
     Zf = 1.0
@@ -370,9 +374,18 @@ def test_BornCollisionFrequency_reproduces_literature_Fortmann2010() -> None:
             jnp.imag(dimless_nu),
         )
         plt.plot(E_over_Ef_imag, nu_imag)
-        plt.plot((E/E_f).m_as(ureg.dimensionless), jnp.imag(dimless_nu), color="black")
+        plt.plot(
+            (E / E_f).m_as(ureg.dimensionless),
+            jnp.imag(dimless_nu),
+            color="black",
+        )
         plt.plot(E_over_Ef_real, nu_real, ls="dashed")
-        plt.plot((E/E_f).m_as(ureg.dimensionless), jnp.real(dimless_nu), ls="dashed", color = "black")
+        plt.plot(
+            (E / E_f).m_as(ureg.dimensionless),
+            jnp.real(dimless_nu),
+            ls="dashed",
+            color="black",
+        )
         plt.xscale("log")
         plt.xlim(0.1, 100)
         plt.show()
@@ -424,6 +437,8 @@ def test_Fortmann_with_LFC_reproduces_literature() -> None:
         V_eiS,
         n_e,
         Zf,
+        jnpu.min(jnpu.absolute(E)),
+        jnpu.max(jnpu.absolute(E)),
         E[jnp.newaxis, :],
         0.0,
         no_of_points=150,
@@ -436,6 +451,8 @@ def test_Fortmann_with_LFC_reproduces_literature() -> None:
         V_eiS,
         n_e,
         Zf,
+        jnpu.min(jnpu.absolute(E)),
+        jnpu.max(jnpu.absolute(E)),
         E[jnp.newaxis, :],
         sLFC,
         no_of_points=150,
@@ -498,10 +515,29 @@ def test_Fortman_reproduces_vanilla_BMA_without_LFC():
         )
 
     classical_BMA = jaxrts.free_free.dielectric_function_BMA_chapman_interpFit(
-        k, E, mu, T, n_e, S_ii, V_eiS, Zf
+        k,
+        E,
+        mu,
+        T,
+        n_e,
+        S_ii,
+        V_eiS,
+        Zf,
+        jnpu.min(jnpu.absolute(E)),
+        jnpu.max(jnpu.absolute(E)),
     )
     fortmann_BMA = jaxrts.free_free.dielectric_function_BMA_Fortmann(
-        k, E, mu, T, n_e, S_ii, V_eiS, Zf, lfc
+        k,
+        E,
+        mu,
+        T,
+        n_e,
+        S_ii,
+        V_eiS,
+        Zf,
+        jnpu.min(jnpu.absolute(E)),
+        jnpu.max(jnpu.absolute(E)),
+        lfc,
     )
     assert jnp.isclose(jnp.real(classical_BMA), jnp.real(fortmann_BMA)).all()
     assert jnp.isclose(jnp.imag(classical_BMA), jnp.imag(fortmann_BMA)).all()


### PR DESCRIPTION
This PR should make the cutoff-energies for the collision frequency interpolation for Born Mermin models more transparent for a user.
We found (with @jorips) that some cases require users to tweak this values. This is now possible when using an appropriate `Model` -- and additionally, these values can now be easily obtained.