### PR TITLE
Improve model docstrings

### DIFF
--- a/doc/examples/ionic/plot_HNC_multicomponent.py
+++ b/doc/examples/ionic/plot_HNC_multicomponent.py
@@ -34,8 +34,8 @@ state = jaxrts.PlasmaState(
     T_e=2e4 * ureg.kelvin,
 )
 
-pot = 15
-r = jnpu.linspace(0.0001 * ureg.angstrom, 1000 * ureg.a0, 2**pot)
+pot = 12
+r = jnpu.linspace(0.0001 * ureg.angstrom, 200 * ureg.a0, 2**pot)
 
 # We add densities, here. Maybe this is wrong.
 d = jnpu.cbrt(

--- a/src/jaxrts/ion_feature.py
+++ b/src/jaxrts/ion_feature.py
@@ -191,6 +191,7 @@ def q_DebyeHueckelChapman2015(
 def free_electron_susceptilibily_RPA(
     k: Quantity,
     kappa: Quantity,
+    lfc: float = 0,
 ):
     """
     Return the free electron susceptilibily given by :cite:`Gericke.2010` eqn 4
@@ -209,6 +210,8 @@ def free_electron_susceptilibily_RPA(
         energies of the incident photons (unit: 1 / [length]).
     kappa : Quantity
         Inverse screening length.
+    lfc: float
+        The local field correction.
 
     Returns
     -------
@@ -216,5 +219,6 @@ def free_electron_susceptilibily_RPA(
         The free electron susceptilibily.
     """
     xi0 = kappa**2 * ureg.epsilon_0 / ((1 * ureg.elementary_charge) ** 2)
-    varepsilon = (k**2 + kappa**2) / (k**2)
+    V_ee = -1 * coulomb_potential_fourier(-1, -1, k)
+    varepsilon = 1 - V_ee * (1 - lfc) * xi0
     return xi0 / varepsilon

--- a/src/jaxrts/literature.bib
+++ b/src/jaxrts/literature.bib
@@ -820,4 +820,41 @@ eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rspa.1957.0106}
   volume = {12},
   pages = {239-247},
 }
-
+@article{Debye.1923,
+  author  = {Debye, P. and H{\"u}ckel, E.},
+  title   = {The theory of electrolytes. I. Lowering of freezing point and related phenomena},
+  journal = {Physikalische Zeitschrift},
+  year    = {1923},
+  volume  = {24},
+  pages   = {185--206}
+}
+@article{Stewart.1966,
+  author  = {Stewart, J. C. and Pyatt, K. D., Jr},
+  title   = {Lowering of Ionization Potentials in Plasmas},
+  journal = {Astrophysical Journal},
+  year    = {1966},
+  volume  = {144},
+  pages   = {1203--1211}
+}
+@article{Rozsnyai.1972,
+  author  = {Rozsnyai, B. F.},
+  title   = {Relativistic Hartree-Fock-Slater Calculations for Arbitrary Temperature and Matter Density},
+  journal = {Physical Review A},
+  year    = {1972},
+  volume  = {5},
+  pages   = {1137--1149},
+  doi     = {10.1103/PhysRevA.5.1137}
+}
+@article{Crowley.2014,
+title = {Continuum lowering – A new perspective},
+journal = {High Energy Density Physics},
+volume = {13},
+pages = {84-102},
+year = {2014},
+issn = {1574-1818},
+doi = {https://doi.org/10.1016/j.hedp.2014.04.003},
+url = {https://www.sciencedirect.com/science/article/pii/S1574181814000287},
+author = {B.J.B. Crowley},
+keywords = {Coulomb systems, Ionization potential depression, Continuum lowering, Photoionization, Plasma equation of state},
+abstract = {What is meant by continuum lowering and ionization potential depression (IPD) in a Coulomb system depends very much upon precisely what question is being asked. It is shown that equilibrium (equation of state) phenomena and non-equilibrium dynamical processes like photoionization are characterized by different values of the IPD. In the former, the ionization potential of an atom embedded in matter is the difference in the free energy of the many-body system between states of thermodynamic equilibrium differing by the ionization state of just one atom. Typically, this energy is less than that required to ionize the same atom in vacuo. Probably, the best known example of this is the IPD given by Stewart and Pyatt (SP). However, it is a common misconception that this formula should apply directly to the energy of a photon causing photoionization, since this is a local adiabatic process that occurs in the absence of a response from the surrounding plasma. To achieve the prescribed final equilibrium state, in general, additional energy, in the form of heat and work, is transferred between the atom and its surroundings. This additional relaxation energy is sufficient to explain the discrepancy between recent spectroscopic measurements of IPD in dense plasmas and the predictions of the SP formula. This paper provides a detailed account of an analytical approach, based on SP, to calculating thermodynamic and spectroscopic (adiabatic) IPDs in multicomponent Coulomb systems of arbitrary coupling strength with Te ≠ Ti. The ramifications for equilibrium Coulomb systems are examined in order to elucidate the roles of the various forms of the IPD and any possible connection with the plasma microfield. The formulation embodies an analytical equation of state (EoS) that is thermodynamically self-consistent, provided that the bound and free electrons are dynamically separable, meaning that the system is not undergoing pressure ionization. Apart from this restriction, the model is applicable in all coupling regimes. The Saha equation, which is generally considered to apply to weakly-coupled non-pressure-ionizing systems, is found to depend on the Thermodynamic IPD (TIPD), a form of the IPD which takes account of entropy changes. The average Static Continuum Lowering (SCL) of SP relates to changes in potential energy alone and features in EoS formulas that depend on the variation of the mean ionization state with respect to changes in volume or temperature. Of the various proposed formulas, the Spectroscopic (adiabatic) IPD (SIPD) gives the most consistent agreement with spectroscopic measurements.}
+}

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -6,7 +6,7 @@ implemented.
 import abc
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Callable
 
 import jax
 import jax.numpy as jnp
@@ -153,22 +153,24 @@ class ScatteringModel(Model):
     to (mainly elastic) scattering models.
     These models have a pre-defined :py:meth:`~.evaluate` method, which is
     performing a convolution with the instrument function, and now requires a
-    user to define :py:meth:`.evaluate_raw` which is giving the scattered
-    energy **without the instrument function**.
+    user to define :py:meth:`.evaluate_raw` which is returning the dynamic
+    structure factor **without the instrument function or any frequency
+    redistribution correction**.
 
     .. note::
 
        As these extra functionalities are only relevant when re-sampling and
        convolution with an instrument function is reasonable, the
-       :py:class:`~.Model` s used to describe ionic scattering are currently
-       not instances of :py:class:`~.ScatteringModel` as the convolution with a
+       :py:class:`~.Model` s used to describe ionic scattering are not
+       instances of :py:class:`~.ScatteringModel` as the convolution with a
        delta function would just result in numerical issues.
+       For ionic scattering, use :py:class:`~IonFeatModel`, instead.
 
-    It furthermore allows a user to set the :py:attr:`~.sample_points`
-    attribute, which is initialized as ``None``.
-    If set, the model is evaluated only on `sample_points` points, rather than
-    all :math:`k` that are probed and is then evaluated. Afterwards, the result
-    is extrapolated to match the :py:class:`~.setup.Setup`'s :math:`k`.
+    A `ScatteringModel` allows users to set the :py:attr:`~.sample_points`
+    attribute, which defaults to ``None``.
+    If set, the model is evaluated only on `sample_points`, equidistant points,
+    rather than at all :math:`k` that are probed. Afterwards, the result is
+    interpolated to match the :py:class:`~.setup.Setup`'s :math:`k`.
     """
 
     def __init__(self, sample_points: int | None = None) -> None:
@@ -266,8 +268,10 @@ scattering_models = [
 
 class Neglect(Model):
     """
-    A model that returns an empty with zeros in (units of seconds) for every
-    energy probed.
+    Universal model to neglect a contribution and set it to zero.
+    For elastic and inelastic energies, return an empty array of zeros in
+    (units of seconds) for every energy probed.
+    If used for the ``IPD`` key, return 0eV, i.e., no IPD.
     """
 
     allowed_keys = [*scattering_models, "ipd"]
@@ -294,10 +298,12 @@ class Neglect(Model):
 # -----------
 class IonFeatModel(Model):
     """
-    These set of models describe the scattering by electrons tightly bound to
-    the ions, causing quasi-elastic scattering. `IonFeatModels` have to define
-    a method :py:meth:`~.S_ii` which returns the static ion-ion structure
-    factor.
+    Abstract class of `Model`s, describing the scattering by electrons tightly
+    bound to the ions, causing quasi-elastic scattering. An `IonFeatModel` has
+    to define a method :py:meth:`~.S_ii` which returns the static ion-ion
+    structure factor. This quantity is used to calculate the
+    :py:meth:`~.Rayleigh_weight` by combining ``form-factors`` and
+    ``screening`` models of the :py:class:`~.PlasmaState`.
     """
 
     #: A list of keywords where this model is adequate for
@@ -321,8 +327,8 @@ class IonFeatModel(Model):
         setup: Setup,
     ) -> jnp.ndarray:
         """
-        This is the result from Wünsch, to calculate the Rayleigh weight for
-        multiple species.
+        This is the result from Wünsch :cite:`Wunsch.2011`, to calculate the
+        Rayleigh weight for a plasma from multiple species.
 
         .. math::
 
@@ -450,7 +456,7 @@ class Gregori2003IonFeat(IonFeatModel):
     Model for the ion feature of the scattering, presented in
     :cite:`Gregori.2003`.
 
-    This model is identical to :py:class:`~ArkhipovIonFeat`, but uses an
+    This model is identical to :py:class:`~ArkhipovIonFeat` but uses an
     effective temperature ~:py:func:`jaxtrs.static_structure_factors.T_cf_Greg`
     rather than the electron Temperature throughout the calculation.
     """
@@ -492,7 +498,7 @@ class Gregori2006IonFeat(IonFeatModel):
     Model for the ion feature of the scattering, presented in
     :cite:`Gregori.2006`.
 
-    This model extends :py:class:`~ArkhipovIonFeat`, to allow for different
+    This model extends :py:class:`~ArkhipovIonFeat` to allow for different
     ion-and electron temperatures.
 
     .. note::
@@ -543,7 +549,9 @@ class Gregori2006IonFeat(IonFeatModel):
 
 class FixedSii(IonFeatModel):
     """
-    Model for the ion feature with a fixed value for :math:`S_{ii}`.
+    Model for the ion feature with a fixed value for :math:`S_{ii}`. Note that
+    the `Sii` has to be returned as a :math:`(n\\times n)` array, where n is
+    the number of component of the plasma.
     """
 
     __name__ = "FixedSii"
@@ -573,17 +581,19 @@ class FixedSii(IonFeatModel):
 
 class OnePotentialHNCIonFeat(IonFeatModel):
     """
-    Model for the ion feature using a calculating all :math:`S_{ab}` in the
-    Hypernetted Chain approximation.
+    Calculates :math:`S_{ab}` in the Hypernetted Chain approximation.
 
     In contrast to :py:class:`~.ThreePotentialHNCIonFeat`, this models
-    calculates only the ion-ion Structure factors, and is neglecting the
-    electron-contibutions. Hence, screening is not included, automatically, but
-    has to be provided as an additional `screening`.
+    calculates only the ion-ion structure factors, and is neglecting the
+    electron-contributions. Hence, screening is not included, automatically,
+    but has to be provided as an additional `screening`. For reasonable
+    results, the 'ion-ion Potential' should account for the fact that the
+    electrons are not included in the HNC scheme. See, e.g.,
+    :cite:`Wunsch.2008`.
 
 
-    Requires an 'ion-ion' (defaults to :py:class:`~DebyeHueckelPotential`) and
-    a `screening` model (default:
+    Requires an 'ion-ion Potential' (defaults to
+    :py:class:`~DebyeHueckelPotential`) and a `screening` model (default:
     :py::class:`~.LinearResponseScreeningGericke2010`. Further requires a
     'form-factors' model (defaults to :py:class:`~PaulingFormFactors`).
     """
@@ -694,18 +704,19 @@ class OnePotentialHNCIonFeat(IonFeatModel):
 
 class ThreePotentialHNCIonFeat(IonFeatModel):
     """
-    Model for the ion feature using a calculating all :math:`S_{ab}` in the
-    Hypernetted Chain approximation. This is achieved by treating the electrons
-    as an additional ion species, that is amended to the list of ions. See,
-    e.g. :cite:`Schwarz.2007`.
+    Calculates :math:`S_{ab}` including electron-ion and electron-electron
+    static structure factors using the Hypernetted Chain approximation. This is
+    achieved by treating the electrons as an additional ion species, that is
+    amended to the list of ions. See, e.g. :cite:`Schwarz.2007`.
 
     .. note::
 
-        Compared to :py:class:`HNCIonFeat`, the internal Variables, `V_s` and
-        `V_l` are now :math:`(n+1 \\times n+1 \\times m)` matrices, where
-        :math:`n` is the number of ion species and :math:`m = 2^\\text{pot}`
-        which pot being :py:attr:`~.pot`, the exponent for the number of
-        scattering vectors to be evaluated in the HNC approach.
+        Compared to :py:class:`OnePotentialHNCIonFeat`, the internal Variables,
+        `V_s` and `V_l` are now :math:`(n+1 \\times n+1 \\times m)` matrices,
+        where :math:`n` is the number of ion species and :math:`m =
+        2^\\text{pot}`. :py:attr:`~.pot` is an attribute defining the number of
+        grid-points evaluated in the HNC approach, which heavily relies on
+        Fourier transforms).
 
     Requires 3 Potentials:
 
@@ -713,7 +724,7 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
           (defaults to :py:class:`~CoulombPotential`).
         - an 'electron-ion Potential' The orange entries in the picture below
           (defaults to :py:class:`~KlimontovichKraeftPotential`).
-        - an 'electron-electron Potential' The red entries in the picutre below
+        - an 'electron-electron Potential' The red entries in the picture below
           (defaults to :py:class:`~KelbgPotental`).
 
     .. image:: ../images/ThreePotentialHNC.svg
@@ -724,8 +735,8 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
 
     jaxrts.ion_feature.q_Glenzer2009
         Calculation of the screening, when both S_ei and S_ii are known. As
-        this should be accurate, we don't require a 'screening' model with this
-        'ionic scttering' model.
+        we directly calculate all static structure factors, we don't require a
+        'screening' model with this 'ionic scattering' model.
 
     """
 
@@ -954,9 +965,9 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
 
 class PeakCollection(IonFeatModel):
     """
-    A model for approximating :py:meth:`~.PeakCollection.S_ii` as a sum of
-    peaks. Can be used to model, e.g., ideal powder diffraction, where elastic
-    signal would only be expected at certain values of :math:`k`.
+    A model for approximating :math:`S_{ii}` as a sum of peaks. Can be used to
+    model, e.g., ideal powder diffraction, where elastic signal would only be
+    expected at certain values of :math:`k`.
     """
 
     __name__ = "PeakCollection"
@@ -965,7 +976,7 @@ class PeakCollection(IonFeatModel):
         self,
         k_pos: Quantity,
         intensity: jnp.ndarray,
-        peak_function: callable,
+        peak_function: Callable[[Quantity], jnp.ndarray],
     ):
         """
         Parameters
@@ -974,13 +985,14 @@ class PeakCollection(IonFeatModel):
             The position of the peaks in :math:`k` space.
         intensity: jnp.ndarray
             The intensity of the peaks. Should have the same length as `k_pos`.
-        peak_function: callable
-            The shape of each peak. This function is expected to be normed over
-            the integral over all :math:`k`, should be centered around 0, and
-            expects to require exactly 1 argument, the position in k space.
-            The `peak_function` should return a shape that is compatible with
-            :py:attr:jaxrts.PlasmaState.nions`. I.e., the output should be a
-            `(nxn)` matrix where `n` is the number of ion species considered.
+        peak_function : Callable[[Quantity], jnp.ndarray]
+            A function defining the shape of a peak. The function must:
+
+            - Be normalized such that its integral over all :math:`k` equals 1.
+            - Be centered at zero in :math:`k`-space.
+            - Accept exactly one argument: a position in :math:`k`-space.
+            - Return an array with shape `(n, n)`, where `n` is the number of
+              ion species (:py:attr:`jaxrts.PlasmaState.nions`).
         """
         self.k_pos = to_array(k_pos)
         self.intensity = to_array(intensity)
@@ -1014,10 +1026,10 @@ class DebyeWallerSolid(IonFeatModel):
     """
     This model approximates the static structure factor (SSF) of a solid at
     finite temperature as suggested by :cite:`Gregori.2006`. It assumes the SSF
-    to consist of a crystall peak feature :math:`b(k)`, which are damped by the
-    debye Waller factor :math:`2W`, and an increasing, diffuse scattering part,
-    which is decribed py the static structure factor :math:`S_\\text{plasma}`
-    of the plasma (or liquid)-seeming contributions.
+    to consist of a crystal peak feature :math:`b(k)`, damped by the Debye
+    Waller factor :math:`2W`, and an increasing, diffuse scattering part, which
+    is described by the static structure factor :math:`S_\\text{plasma}` of the
+    plasma (or liquid) contributions.
 
     .. math::
 
@@ -1026,9 +1038,8 @@ class DebyeWallerSolid(IonFeatModel):
 
     .. note::
 
-       For the temperatures this model might be used,
-       :math:`S_\\text{plasma}(k) = 1` has been used in the literature, before
-       to extract Debye temperatures from DFT-MD Simulations. See
+       Inverting this model and using :math:`S_\\text{plasma}(k) = 1` has
+       allowed to extract Debye temperatures from DFT-MD simulations
        :cite:`Schuster.2020`.
 
     This function uses the :py:class:`jaxrts.plasmastate.PlasmaState` ``'Debye
@@ -1040,8 +1051,8 @@ class DebyeWallerSolid(IonFeatModel):
     --------
     jaxrts.static_structure_factors.debyeWallerFactor
        Function used to calculate the Debye Waller Factor. Note that the
-       implementation used based on :cite:`Murphy.2008` does differ from the
-       formula in :cite:`Gregori.2006`.
+       implementation used in jaxrts is based on :cite:`Murphy.2008` and
+       differs from the formula in :cite:`Gregori.2006`.
     """
 
     __name__ = "DebyeWallerSolid"
@@ -1116,7 +1127,7 @@ class FreeFreeModel(ScatteringModel):
     """
     A class of models suitable for ``'free-free scattering'``. These models
     have to define a :py:meth:`~.susceptibility` method, which can be used by a
-    ``'screening'`` model, later.
+    ``'screening'`` Model, later.
     """
 
     #: A list of keywords where this model is adequate for
@@ -1140,15 +1151,15 @@ class QCSalpeterApproximation(FreeFreeModel):
     the results by Salpeter (:cite:`Salpeter.1960`), increasing the range of
     applicability.
 
-    However, this model might be rather considered to be educational, as it is
-    only valid for small(er) densities and probing energies. Instead, one might
-    use :py:class:~RPA_NoDamping`, which should give more accurate results
-    (according to, e.g., "cite:`Gregori.2003`) at a comparable computation
-    time.
+    However, this model should mainly be rather considered to be educational,
+    as it is only valid for small(er) densities and probing energies. Instead,
+    for most practical use-cases one might use :py:class:~RPA_DandreaFit` which
+    should give more accurate results (according to, e.g.,
+    "cite:`Gregori.2003`) at a comparable computation time.
 
     This model does not provide a straight-forward approach to include local
-    field corrections. We have included it, for now, by assuming the behavior
-    would be the same as it is for the RPA.
+    field corrections. We have included it, by assuming the behavior would be
+    the same as it is for the RPA.
 
     See Also
     --------
@@ -1215,10 +1226,11 @@ class QCSalpeterApproximation(FreeFreeModel):
 class RPA_NoDamping(FreeFreeModel):
     """
     Model for elastic free-free scattering based on the Random Phase
-    Approximation
+    Approximation.
 
-    Calculates the dielectic function in RPA and obtain a Structure factor via
-    the fluctuation dissipation theorem. Based on lecture notes from M. Bonitz.
+    Calculates the dielectric function in RPA and obtain a Structure factor via
+    the fluctuation dissipation theorem. Implementation is based on lecture
+    notes from M. Bonitz.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~IchimaruChemPotential`).
@@ -1372,19 +1384,20 @@ class RPA_DandreaFit(FreeFreeModel):
 
 class BornMerminFull(FreeFreeModel):
     """
-    Model of the free-free scattering, based on the Born Mermin Approximation
+    Model for the free-free scattering, based on the Born Mermin Approximation
     (:cite:`Mermin.1970`).
 
     Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
-    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
-    is used, otherwise, use the formulas that are found, e.g., in
-    :cite:`Schorner.2023`.
+    ``True``, we solve the RPA integral as formulated by :cite:`Chapman.2015`
+    Otherwise, use the formulas that are found, e.g., in :cite:`Schorner.2023`.
+    The former implementation yields more stable results, most of the time.
 
-    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    The model has the optional attribute ``KKT``, defaulting to ``False``,
     using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
-    We found for edge cases to avoid numerical spikes.
+    We found for edge cases this behavior was beneficial to avoid numerical
+    spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
@@ -1551,12 +1564,12 @@ class BornMerminFull(FreeFreeModel):
 
 class BornMermin(FreeFreeModel):
     """
-    Model of the free-free scattering, based on the Born Mermin Approximation
+    Model for the free-free scattering, based on the Born Mermin Approximation
     (:cite:`Mermin.1970`).
     Uses the Chapman interpolation which allows for a faster computation of the
-    free-free scattering compared to :py:class:`~.BornMerminFull`, by sampleing
-    at the probing frequency at :py:attr:`~.no_of_freq` points and
-    interpolating between them, after.
+    free-free scattering compared to :py:class:`~.BornMerminFull`, by sampling
+    the probing frequency at :py:attr:`~.no_of_freq` points and interpolating
+    between them, after.
 
     The number of frequencies defaults to 20 if ``KKT`` is ``False``, and to
     100 otherwise. To change it, just change the attribute of this model after
@@ -1565,8 +1578,8 @@ class BornMermin(FreeFreeModel):
     >>> state["free-free scattering"] = jaxrts.models.BornMermin()
     >>> state["free-free scattering"].no_of_freq = 10
 
-    The boundaries for this interpolation can be set as arguments
-    ``E_cutoff_min`` and ``E_cutoff_max``. It should be set to sane defaults
+    The boundaries for this interpolation can be given as arguments
+    ``E_cutoff_min`` and ``E_cutoff_max``. They should be set to sane defaults
     for most use cases; however, it is recommended to revisit this setting
     carefully. As a minimal good practice, the defaults should be adjusted to
     the setup used. This can be done with the
@@ -1575,15 +1588,16 @@ class BornMermin(FreeFreeModel):
     >>> state["free-free scattering"].set_guessed_E_cutoffs(state, setup)
 
     Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
-    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
-    is used, otherwise, use the formulas that are found, e.g., in
-    :cite:`Schorner.2023`.
+    ``True``, we solve the RPA integral as formulated by :cite:`Chapman.2015`
+    Otherwise, use the formulas that are found, e.g., in :cite:`Schorner.2023`.
+    The former implementation yields more stable results, most of the time.
 
-    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    The model has the optional attribute ``KKT``, defaulting to ``False``,
     using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
-    We found for edge cases to avoid numerical spikes.
+    We found for edge cases this behavior was beneficial to avoid numerical
+    spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
@@ -1836,22 +1850,22 @@ class BornMermin(FreeFreeModel):
 
 class BornMermin_Fit(FreeFreeModel):
     """
-    Model of the free-free scattering, based on the Born Mermin Approximation
+    Model for the free-free scattering, based on the Born Mermin Approximation
     (:cite:`Mermin.1970`).
     Identical to :py:class:`~.BornMermin`, but uses the Dandrea
     fit (:cite:`Dandrea.1986`), rather than numerically calculating the
-    un-damped RPA, numerically. However, the damped RPA is still evaluated
-    using the integral.
+    un-damped RPA. However, the damped RPA is still evaluated using the
+    adequate integral.
 
-    The number of frequencies defaults to 20 if ``KKT`` is ``False``, and to
-    100 otherwise. To change it, just change the attribute of this model after
-    initializing it. i.e.
+    The number of frequencies for the Chapman interpolation defaults to 20 if
+    ``KKT`` is ``False``, and to 100 otherwise. To change it, just change the
+    attribute of this model after initializing it. i.e.
 
     >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fit()
     >>> state["free-free scattering"].no_of_freq = 10
 
-    The boundaries for this interpolation can be set as arguments
-    ``E_cutoff_min`` and ``E_cutoff_max``. It should be set to sane defaults
+    The boundaries for the interpolation can be given as arguments
+    ``E_cutoff_min`` and ``E_cutoff_max``. They should be set to sane defaults
     for most use cases; however, it is recommended to revisit this setting
     carefully. As a minimal good practice, the defaults should be adjusted to
     the setup used. This can be done with the
@@ -1860,15 +1874,16 @@ class BornMermin_Fit(FreeFreeModel):
     >>> state["free-free scattering"].set_guessed_E_cutoffs(state, setup)
 
     Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
-    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
-    is used, otherwise, use the formulas that are found, e.g., in
-    :cite:`Schorner.2023`.
+    ``True``, we solve the RPA integral as formulated by :cite:`Chapman.2015`
+    Otherwise, use the formulas that are found, e.g., in :cite:`Schorner.2023`.
+    The former implementation yields more stable results, most of the time.
 
-    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    The model has the optional attribute ``KKT``, defaulting to ``False``,
     using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
-    We found for edge cases to avoid numerical spikes.
+    We found for edge cases this behavior was beneficial to avoid numerical
+    spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
@@ -2121,22 +2136,22 @@ class BornMermin_Fit(FreeFreeModel):
 
 class BornMermin_Fortmann(FreeFreeModel):
     """
-    Model of the free-free scattering, based on the Born Mermin Approximation
+    Model for the free-free scattering, based on the Born Mermin Approximation
     (:cite:`Mermin.1970`).
-    Uses the same collision frequency as :py:class:`~.BornMermin_Fit`
-    (including the :cite:`Dandrea.1986` fit), but uses a rigorous
+    Uses the same assumptions as :py:class:`~.BornMermin_Fit` (including the
+    :cite:`Dandrea.1986` fit for the un-damped RPA), but uses a rigorous
     implementation of the local field correction, proposed by
     :cite:`Fortmann.2010`.
 
-    The number of frequencies defaults to 20 if ``KKT`` is ``False``, and to
-    100 otherwise. To change it, just change the attribute of this model after
-    initializing it. i.e.
+    The number of frequencies for the Champan interpolation defaults to 20 if
+    ``KKT`` is ``False``, and to 100 otherwise. To change it, just change the
+    attribute of this model after initializing it. i.e.
 
     >>> state["free-free scattering"] = jaxrts.models.BornMermin_Fortmann()
     >>> state["free-free scattering"].no_of_freq = 10
 
-    The boundaries for this interpolation can be set as arguments
-    ``E_cutoff_min`` and ``E_cutoff_max``. It should be set to sane defaults
+    The boundaries for the interpolation can be given as arguments
+    ``E_cutoff_min`` and ``E_cutoff_max``. They should be set to sane defaults
     for most use cases; however, it is recommended to revisit this setting
     carefully. As a minimal good practice, the defaults should be adjusted to
     the setup used. This can be done with the
@@ -2145,15 +2160,16 @@ class BornMermin_Fortmann(FreeFreeModel):
     >>> state["free-free scattering"].set_guessed_E_cutoffs(state, setup)
 
     Has the optional argument ``RPA_rewrite``, which defaults to ``True``. If
-    ``True``, the integral RPA integral as formulated by :cite:`Chapman.2015`
-    is used, otherwise, use the formulas that are found, e.g., in
-    :cite:`Schorner.2023`.
+    ``True``, we solve the RPA integral as formulated by :cite:`Chapman.2015`
+    Otherwise, use the formulas that are found, e.g., in :cite:`Schorner.2023`.
+    The former implementation yields more stable results, most of the time.
 
-    Furtemore, it has the optional attribute ``KKT``, defaulting to ``False``,
+    The model has the optional attribute ``KKT``, defaulting to ``False``,
     using :py:func:`jaxrts.free_free.KramersKronigTransform`, for the imaginary
     part of the collision frequency, rather than solving the integral for the
     imaginary part, as well.
-    We found for edge cases to avoid numerical spikes.
+    We found for edge cases this behavior was beneficial to avoid numerical
+    spikes.
 
     Requires a 'chemical potential' model (defaults to
     :py:class:`~.IchimaruChemPotential`).
@@ -2405,8 +2421,8 @@ class SchumacherImpulse(ScatteringModel):
 
     Should yield similar results as
     :py:class:`~.SchumacherImpulseColdEdges`. However, rather than using
-    absorption edges being of the cold sample, here we use edges of
-    isolated ions in a plasma instead.
+    absorption edges beof the cold sample, here we use edges of isolated ions
+    in a plasma instead.
 
     Requires a 'form-factors' model (defaults to
     :py:class:`~PaulingFormFactors`).
@@ -2420,7 +2436,7 @@ class SchumacherImpulse(ScatteringModel):
 
     def __init__(self, r_k: float | None = None) -> None:
         """
-        r_k is the correction given in :cite:`Gregori.2004`. If None, or if a
+        r_k is the correction given in :cite:`Gregori.2004`. If `None`, or if a
         negative value is given, we use the formula given by
         :cite:`Gregori.2004`. Otherwise, it is just the value provided by the
         user.
@@ -2713,7 +2729,8 @@ class SchumacherImpulseFitRk(ScatteringModel):
     Bound-free scattering based on the Schumacher Impulse Approximation
     :cite:`Schumacher.1975`. The implementation considers the first order
     asymmetric correction to the impulse approximation, as given in the
-    aforementioned paper. The r_k factor is fitted to fulfill the f-sum rule.
+    aforementioned paper. The r_k factor is set so that the full spectrum
+    fulfills the f-sum rule (See :cite:`Dornheim.2024`).
     Note, that this implementation is still experimental.
 
     Requires a 'form-factors' model (defaults to
@@ -2843,9 +2860,9 @@ class DetailedBalance(ScatteringModel):
 
     .. note::
 
-       This model requires to have an `evaluate_raw` method for the bound-free
-       model, which should return the bound-free scattering intensity **not
-       convolved** with an instrument function.
+       This model requires the ound-free model to have an `evaluate_raw`, which
+       should return the bound-free scattering intensity **not convolved** with
+       an instrument function. (See :py:class:`~.ScatteringModel`).
 
     .. note::
 
@@ -2913,13 +2930,14 @@ class PaulingFormFactors(Model):
 
 class FormFactorLowering(Model):
     """
-    Form factor lowering model as introduced by :cite:`Doeppner.2023`.
-    In high density plasma the form factor is reduced due to IPD.
-    This concept only applies for the K-shell. Here we calculate the f1s(k)
-    form factor with the analytic Pauling formular but with an IPD corrected
-    effective charge Z_eff. The spin up and spin down K-shell electrons and
-    their respective binding energies are taken into account for this
-    calculation.
+    Form factor lowering model as introduced by :cite:`Doppner.2023`.
+    In a high density plasma the form factor is reduced due to ionization
+    potential depression. This concept only applies to very high densities,
+    when only K-shell electrons should remain. Here we calculate the
+    :math:`f_{1s}(k)` form factor with the analytic Pauling formula but with an
+    IPD corrected effective charge `Z_eff`. The spin up and spin down K-shell
+    electrons and their respective binding energies are taken into account for
+    this calculation.
 
     .. note::
 
@@ -3044,7 +3062,7 @@ class IchimaruChemPotential(Model):
 
 class ConstantChemPotential(Model):
     """
-    A model that returns an a constant for each energy probed.
+    A model that returns a constant chemical potential, specified by a user.
     """
 
     allowed_keys = ["chemical potential"]
@@ -3298,8 +3316,8 @@ class PauliBlockingIPD(Model):
 
 class DebyeHueckelScreeningLength(Model):
     """
-    This is just the normal Debye Hückel screening length. Use the electron
-    temperature for the known formula
+    The Debye Hückel screening length of the electrons. Use the electron
+    temperature for the known formula with `Z=1`.
 
     See also
     --------
@@ -3319,8 +3337,8 @@ class DebyeHueckelScreeningLength(Model):
 
 class Gericke2010ScreeningLength(Model):
     """
-    Return the Debye-Hückel Debye screening length. Uses a 4th-power
-    interpolation between electron and fermi temperature, as proposed by
+    Return the Debye-Hückel screening length. Uses a 4th-power
+    interpolation between electron and Fermi temperature, as proposed by
     :cite:`Gericke.2010`
 
     See Also
@@ -3409,28 +3427,46 @@ class ConstantScreeningLength(Model):
 # ================
 #
 # These models should return a `q`, the screening by free electrons which is
-# relevant when calculating the Raighley weight.
+# relevant when calculating the Rayleigh weight.
 
 
 class LinearResponseScreeningGericke2010(Model):
     """
     The screening density :math:`q` is calculated using a result from linear
-    response, by
+    response:
 
     .. math::
 
-       q(k) = \\xi_{ee}^{RPA} V_{ei}(k)
+       q(k) = \\chi_{ee}^\\text{DH} V_{ei}(k)
 
 
-    See :cite:`Wunsch.2011`, Eqn(5.22) and :cite:`Gericke.2010` Eqn(3).
+    See :cite:`Wunsch.2011`, Eqn(5.22) and :cite:`Gericke.2010` Eqn(3). The
+    susceptibility is calculated using the Debye Hückel dielectric function,
+    accessing the 'screening length' model of the plasma state.
+
+    .. math::
+
+       \\chi_ee^\\text{DH} = \\chi^0_{ee} / (1 - V_{ee}(1-LFC)\\chi^0_{ee})
+       \\chi^0_{ee} = \\frac{\\kappa_e \\varepsilon_0}{e^2}
+
+    :math:`kappa_e` is the screening length, LFC the local field correction
+    used, and V_{ee} the Coulomb potential.
 
     Requires an 'electron-ion' potential. (defaults to
     :py:class:`~KlimontovichKraeftPotential`).
 
+
+    .. note::
+
+       This model should reduce to the :py:class:`~.DebyeHueckelScreening`,
+       model if the local field correction is 0, and the electron-ion is a
+       Coulomb potential.
+
+
     See Also
     --------
-    jaxtrs.ion_feature.free_electron_susceptilibily
-        Function used to calculate :math:`\\xi{ee}`
+    jaxtrs.ion_feature.free_electron_susceptilibily_RPA
+        Function used to calculate :math:`\\xi{ee}^\\text{RPA}`
     """
 
     allowed_keys = ["screening"]
@@ -3475,10 +3511,25 @@ class LinearResponseScreeningGericke2010(Model):
 
 class FiniteWavelengthScreening(Model):
     """
-    Finite wavelenth screening as presented by :cite:`Chapman.2015b`.
+    Finite wavelength screening as presented by :cite:`Chapman.2015b`, using a
+    using a result from linear to calculate the screening density :math:`q`:
+
+    .. math::
+
+       q(k) = \\chi_{ee}^\\text{RPA} V_{ei}(k)
+
+
+    The RPA is calculated using the fit formula from :cite:`Dandrea.1986`.
 
     Should be identical to :py:class:`~.LinearResponseScreening`, if the
     free-free model is a RPA model.
+
+    .. note::
+
+       Due to the above definition, the 'screening length' ``Model`` of the
+       plasma state is of no relevance for the evaluation of this Screening
+       Model.
+
 
     See also
     --------
@@ -3488,7 +3539,7 @@ class FiniteWavelengthScreening(Model):
 
     allowed_keys = ["screening"]
     __name__ = "FiniteWavelengthScreening"
-    cite_keys = ["Chapman.2015b"]
+    cite_keys = ["Chapman.2015b", ("Dandrea.1986", "Analytical Fit for RPA")]
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
         plasma_state.update_default_model(
@@ -3525,6 +3576,21 @@ class DebyeHueckelScreening(Model):
     """
     Debye Hueckel screening as presented by :cite:`Chapman.2015b`.
 
+    .. math::
+
+       q^\\text{DH} = Z_f \\frac{\\kappa_e^*2}{\\kappa_e^2 + k^2}
+
+
+    Where :math:`\\kappa_e` is given by the 'screening length' model.
+
+    .. note::
+
+       This model should give the same results as
+       :py:class:`~.LinearResponseScreeningGericke2010`, if the latter is
+       evaluated with a local field correction of 0, and the electron-ion
+       potential being a Coulomb potential
+
+
     See also
     --------
     jaxrts.ion_feature.q_DebyeHueckelChapman2015
@@ -3559,21 +3625,21 @@ class DebyeHueckelScreening(Model):
 class LinearResponseScreening(Model):
     """
     The screening density :math:`q` is calculated using a result from linear
-    response, by
+    response:
 
     .. math::
 
-       q(k) = \\xi_{ee} V_{ei}(k)
+       q(k) = \\chi_{ee} V_{ei}(k)
 
 
     See :cite:`Wunsch.2011`, Eqn(5.22) and :cite:`Gericke.2010` Eqn(3).
 
-    Requires an 'electron-ion' potential. (defaults to
-    :py:class:`~KlimontovichKraeftPotential`).
-
     Uses the :py:meth:`~.FreeFreeModel.susceptibility` method of the chosen
     Free Free model. If not free-free model is specified, set the default to
     :py:class:`~.RPA_DandreaFit`.
+
+    Requires an 'electron-ion' potential. (defaults to
+    :py:class:`~KlimontovichKraeftPotential`).
     """
 
     allowed_keys = ["screening"]
@@ -3615,7 +3681,11 @@ class LinearResponseScreening(Model):
 class Gregori2004Screening(Model):
     """
     Calculating the screening from free electrons according to
-    :cite:`Gregori.2004`.
+    :cite:`Gregori.2004`. This implementation of the screening relies on
+    calculating static sturcture factors for the ion-electron system by the
+    work of Arkhipov (:cite:`Arkhipov.1998` and :cite:`Arkhipov.2000`) -- with
+    the limits in applicablity for a dense plasma, as, among others, work by
+    :cite:`Schwarz.2007` shows.
 
     See Also
     --------
@@ -3738,7 +3808,7 @@ class ElectronicLFCUtsumiIchimaru(Model):
 
 class ElectronicLFCDornheimAnalyticalInterp(Model):
     """
-    Static local field correction model by Dornheim et al
+    Static local field correction model by Dornheim et al.
     :cite:`Dornheim.2021`. Their model is an analytical interpolation of
     ab-initio PIMC simulations.
 
@@ -4121,7 +4191,8 @@ class DebyeHueckel_BM_V(BM_V_eiSModel):
 class FiniteWavelength_BM_V(BM_V_eiSModel):
     """
     Uses finite wavelength screening to screen the bare Coulomb potential,
-    i.e., :math:`V_{s} = \\frac{V_\\mathrm{Coulomb}}{\\vareps_{RPA}(k, E=0)}`
+    i.e.,
+    :math:`V_{s}=\\frac{V_\\mathrm{Coulomb}}{\\varepsilon_\\text{RPA}(k, E=0)}`
 
     We use the pure RPA result to calculate the dielectric function, and use
     the :cite:`Dandrea.1986` fitting formula.

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -3278,10 +3278,15 @@ class EckerKroellIPD(Model):
     """
     Ecker-Kröll IPD Model:cite:`EckerKroell.1963`.
 
-    Opposite to the Stewart-Pyatt:cite:`Stewart.1966` Model the Ecker-Kröll Model assumes that the relevant length scale for determining the IPD
-    in high-density plasmas is not R_0 (the ion sphere radius) but rather the average distance between all free particles r^3_EK = 3/4\pi(n_e + n_i),
+    Opposite to the Stewart-Pyatt:cite:`Stewart.1966` Model the Ecker-Kröll
+    Model assumes that the relevant length scale for determining the IPD in
+    high-density plasmas is not R_0 (the ion sphere radius) but rather the
+    average distance between all free particles r^3_EK = 3/4\\pi(n_e + n_i),
     where n_e and n_i are the ion and electron number density.
-    The Ecker-Kröll Model predicts a far higher IPD than the Stewart-Pyatt Model for highly ionized plasmas. 
+    The Ecker-Kröll Model predicts a far higher IPD than the Stewart-Pyatt
+    Model for highly ionized plasmas. 
+
+    See also
     --------
     jaxrts.ipd.ipd_ecker_kroell
         Function used to calculate the IPD

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -710,7 +710,7 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
     Requires 3 Potentials:
 
         - an 'ion-ion Potential' The black entries in the picture below
-          (defaults to :py:class:`~DebyeHueckelPotential`).
+          (defaults to :py:class:`~CoulombPotential`).
         - an 'electron-ion Potential' The orange entries in the picture below
           (defaults to :py:class:`~KlimontovichKraeftPotential`).
         - an 'electron-electron Potential' The red entries in the picutre below
@@ -777,7 +777,7 @@ class ThreePotentialHNCIonFeat(IonFeatModel):
         # screening model
         plasma_state.update_default_model("form-factors", PaulingFormFactors())
         plasma_state.update_default_model(
-            "ion-ion Potential", hnc_potentials.DebyeHueckelPotential()
+            "ion-ion Potential", hnc_potentials.CoulombPotential()
         )
         plasma_state.update_default_model(
             "electron-ion Potential",

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -3457,7 +3457,8 @@ class LinearResponseScreeningGericke2010(Model):
 
         # Use the Debye screening length for the screening cloud.
         kappa = 1 / plasma_state.screening_length
-        xi = ion_feature.free_electron_susceptilibily_RPA(setup.k, kappa)
+        lfc = plasma_state["ee-lfc"].evaluate(plasma_state, setup)
+        xi = ion_feature.free_electron_susceptilibily_RPA(setup.k, kappa, lfc)
         Vei = plasma_state["electron-ion Potential"].full_k(
             plasma_state, to_array(setup.k)[jnp.newaxis]
         )

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -3163,7 +3163,7 @@ class BohmStaver(Model):
 
 class ConstantIPD(Model):
     """
-    A model that returns constant value for the IPD.
+    A model that returns a constant value for the IPD, set by the user.
     """
 
     allowed_keys = ["ipd"]
@@ -3196,9 +3196,10 @@ class ConstantIPD(Model):
 
 class DebyeHueckelIPD(Model):
     """
-    Debye Hückel IPD Model
-
-    See Also
+    Debye-Hückel IPD Model :cite:`Debye.1923`.
+    The Debye-Hückel Model is applicable for low-density and high-temperature
+    plasmas, determined by charge screening effects as described in the
+    Debye-Hückel theory.
     --------
     jaxrts.ipd.ipd_debye_hueckel
         Function used to calculate the IPD
@@ -3206,6 +3207,7 @@ class DebyeHueckelIPD(Model):
 
     allowed_keys = ["ipd"]
     __name__ = "DebyeHueckel"
+    cite_keys = ["Debye.1923", "Crowley.2014"]
 
     @jax.jit
     def evaluate(self, plasma_state: "PlasmaState", setup: Setup) -> Quantity:
@@ -3220,9 +3222,11 @@ class DebyeHueckelIPD(Model):
 
 class StewartPyattIPD(Model):
     """
-    Stewart Pyatt IPD Model.
+    Stewart Pyatt IPD Model :cite:`Stewart.1966`.
+    The Stewart–Pyatt (SP) model interpolates between the
+    Debye–Hückel :cite:`Debye.1923` and Ion-Sphere model :cite:`Rozsnyai.1972` 
+    at (low T, high rho) and (high T, low rho), respectively.
 
-    See Also
     --------
     jaxrts.ipd.ipd_stewart_pyatt
         Function used to calculate the IPD
@@ -3230,6 +3234,7 @@ class StewartPyattIPD(Model):
 
     allowed_keys = ["ipd"]
     __name__ = "StewartPyatt"
+    cite_keys = ["Stewart.1966", "Crowley.2014"]
 
     @jax.jit
     def evaluate(self, plasma_state: "PlasmaState", setup: Setup) -> Quantity:
@@ -3244,9 +3249,15 @@ class StewartPyattIPD(Model):
 
 class IonSphereIPD(Model):
     """
-    Ion Sphere IPD Model.
+    Ion Sphere IPD Model :cite:`Rozsnyai.1972`.
+    
+    The Ion Sphere Model (IS) is especially applicable plasmas with strong ion
+    coupling, and thus in particular for high density, low temperature plasmas.
+    The relevant length scale that determines the ionization potential is the
+    ion sphere radius R_0, determined by the condition that a sphere of radius
+    R_0 contains the same charge as given by the mean ionization and the
+    electron number density.
 
-    See Also
     --------
     jaxrts.ipd.ipd_ion_sphere
         Function used to calculate the IPD
@@ -3254,6 +3265,7 @@ class IonSphereIPD(Model):
 
     allowed_keys = ["ipd"]
     __name__ = "IonSphere"
+    cite_keys = ["Rozsnyai.1972", "Crowley.2014"]
 
     @jax.jit
     def evaluate(self, plasma_state: "PlasmaState", setup: Setup) -> Quantity:
@@ -3264,9 +3276,12 @@ class IonSphereIPD(Model):
 
 class EckerKroellIPD(Model):
     """
-    Ecker Kröll IPD Model.
+    Ecker-Kröll IPD Model:cite:`EckerKroell.1963`.
 
-    See Also
+    Opposite to the Stewart-Pyatt:cite:`Stewart.1966` Model the Ecker-Kröll Model assumes that the relevant length scale for determining the IPD
+    in high-density plasmas is not R_0 (the ion sphere radius) but rather the average distance between all free particles r^3_EK = 3/4\pi(n_e + n_i),
+    where n_e and n_i are the ion and electron number density.
+    The Ecker-Kröll Model predicts a far higher IPD than the Stewart-Pyatt Model for highly ionized plasmas. 
     --------
     jaxrts.ipd.ipd_ecker_kroell
         Function used to calculate the IPD
@@ -3274,6 +3289,7 @@ class EckerKroellIPD(Model):
 
     allowed_keys = ["ipd"]
     __name__ = "EckerKroell"
+    cite_keys = ["EckerKroell.1963", "Crowley.2014"]
 
     @jax.jit
     def evaluate(self, plasma_state: "PlasmaState", setup: Setup) -> Quantity:
@@ -3288,9 +3304,14 @@ class EckerKroellIPD(Model):
 
 class PauliBlockingIPD(Model):
     """
-    Pauli Blocking IPD Model.
+    Pauli Blocking IPD Model :cite:`Ropke.2019`.
 
-    See Also
+    In dense plasma the bound state energies get modified due to the Pauli
+    exclusion principle, thereby lowering the ionization potential from below.
+    Additionally, the Pauli Blocking IPD Model should be supplemented by a
+    model that lowers the continuum and hence the ionization potential from
+    above.
+
     --------
     jaxrts.ipd.ipd_pauli_blocking
         Function used to calculate the IPD
@@ -3298,6 +3319,7 @@ class PauliBlockingIPD(Model):
 
     allowed_keys = ["ipd"]
     __name__ = "PauliBlocking"
+    cite_keys = ["Ropke.2019"]
 
     @jax.jit
     def evaluate(self, plasma_state: "PlasmaState", setup: Setup) -> Quantity:
@@ -3316,8 +3338,8 @@ class PauliBlockingIPD(Model):
 
 class DebyeHueckelScreeningLength(Model):
     """
-    The Debye Hückel screening length of the electrons. Use the electron
-    temperature for the known formula with `Z=1`.
+    This is standard Debye Hückel screening length. See also
+    :cite:`Gericke.2010`.
 
     See also
     --------
@@ -3327,6 +3349,7 @@ class DebyeHueckelScreeningLength(Model):
 
     allowed_keys = ["screening length"]
     __name__ = "DebyeHueckelScreeningLength"
+    cite_keys = ["Debye.1923"]
 
     @jax.jit
     def evaluate(self, plasma_state: "PlasmaState", setup: Setup) -> Quantity:
@@ -3368,7 +3391,7 @@ class ArbitraryDegeneracyScreeningLength(Model):
     """
     A screening length valid for arbitrary degeneracy.
 
-    See Also
+    See Also :cite:`Ropke.2019`.
     --------
     ipd.inverse_screening_length_e
         The function used to calculate the inverse of the screening length


### PR DESCRIPTION
Some improvements of Model doc strings, as well as fix for the default potentials for `ThreePotentialHNCIonFeat`