### PR TITLE
perf: Speed up HNC calculation

### DIFF
--- a/src/jaxrts/helpers.py
+++ b/src/jaxrts/helpers.py
@@ -186,6 +186,7 @@ def mass_density_from_electron_density(
     partial: boolean
         default false = density of mixture, if true: density vector splitted
         for mixture is returned.
+
     Returns
     -------
     array_like
@@ -465,8 +466,8 @@ def cramer_solve(A, b, N_max=4):
         be performed. If the size is bigger than `N_max`, fall back to
         ``jax.linalg.solve``.
 
-    Returns:
-    --------
+    Returns
+    -------
     x: jnp.narray
         Shape (..., N), so that :math:`A x = b`
     """

--- a/src/jaxrts/helpers.py
+++ b/src/jaxrts/helpers.py
@@ -435,6 +435,316 @@ def read_nist_file(config) -> (jnp.ndarray, Quantity):
     return jnp.array(g), jnp.array(E) * ureg.electron_volt
 
 
+def cramer_solve(A, b, N_max=4):
+    """
+    Solve A x = b via Cramer's rule for small, fixed system sizes, avoiding the
+    fixed dispatch overhead of a batched jnp.linalg.solve. Falls back to
+    jnp.linalg.solve for sizes not hand-coded below.
+    For small matrices, e.g., 2 component HNC, this does serve as a notable
+    speedup.
+
+    .. warning::
+
+       Using this function if a tradeoff of speed (for small systems) over
+       numerical stability. We found that for the application in HNC with few
+       components, this works reasonably well. Setting ``M_max`` to 0 allows to
+       bypass explicit calculation, if required.
+
+    A: (..., N, N), b: (..., N). N must be static (known at trace time).
+    Works either called directly on a batched array, or from inside a
+    vmap-mapped function (where A, b appear unbatched, shape (N,N) & (N,)).
+
+    Parameters
+    ----------
+    A: jnp.ndarray
+        Shape (..., N, N) matrix to be inverted
+    b: jnp.ndarray
+        Shape (..., N) array of solutions
+    N_max: int
+        Maximal size of the matrix for which the hand-written inversion should
+        be performed. If the size is bigger than `N_max`, fall back to
+        ``jax.linalg.solve``.
+
+    Returns:
+    --------
+    x: jnp.narray
+        Shape (..., N), so that :math:`A x = b`
+    """
+    N = A.shape[-1]
+    # Directly return the linalg solve based
+    if N > N_max:
+        return jnp.linalg.solve(A, b)
+
+    if N == 1:
+        return b / A[..., 0, 0][..., None]
+
+    if N == 2:
+        a00, a01 = A[..., 0, 0], A[..., 0, 1]
+        a10, a11 = A[..., 1, 0], A[..., 1, 1]
+        b0, b1 = b[..., 0], b[..., 1]
+
+        det = a00 * a11 - a01 * a10
+        x0 = (a11 * b0 - a01 * b1) / det
+        x1 = (-a10 * b0 + a00 * b1) / det
+        return jnp.stack([x0, x1], axis=-1)
+
+    if N == 3:
+        a00, a01, a02 = A[..., 0, 0], A[..., 0, 1], A[..., 0, 2]
+        a10, a11, a12 = A[..., 1, 0], A[..., 1, 1], A[..., 1, 2]
+        a20, a21, a22 = A[..., 2, 0], A[..., 2, 1], A[..., 2, 2]
+        b0, b1, b2 = b[..., 0], b[..., 1], b[..., 2]
+
+        c00 = a11 * a22 - a12 * a21
+        c01 = -(a10 * a22 - a12 * a20)
+        c02 = a10 * a21 - a11 * a20
+        c10 = -(a01 * a22 - a02 * a21)
+        c11 = a00 * a22 - a02 * a20
+        c12 = -(a00 * a21 - a01 * a20)
+        c20 = a01 * a12 - a02 * a11
+        c21 = -(a00 * a12 - a02 * a10)
+        c22 = a00 * a11 - a01 * a10
+
+        det = a00 * c00 + a01 * c01 + a02 * c02
+
+        x0 = (c00 * b0 + c10 * b1 + c20 * b2) / det
+        x1 = (c01 * b0 + c11 * b1 + c21 * b2) / det
+        x2 = (c02 * b0 + c12 * b1 + c22 * b2) / det
+        return jnp.stack([x0, x1, x2], axis=-1)
+
+    if N == 4:
+        a00, a01, a02, a03 = (
+            A[..., 0, 0],
+            A[..., 0, 1],
+            A[..., 0, 2],
+            A[..., 0, 3],
+        )
+        a10, a11, a12, a13 = (
+            A[..., 1, 0],
+            A[..., 1, 1],
+            A[..., 1, 2],
+            A[..., 1, 3],
+        )
+        a20, a21, a22, a23 = (
+            A[..., 2, 0],
+            A[..., 2, 1],
+            A[..., 2, 2],
+            A[..., 2, 3],
+        )
+        a30, a31, a32, a33 = (
+            A[..., 3, 0],
+            A[..., 3, 1],
+            A[..., 3, 2],
+            A[..., 3, 3],
+        )
+        b0, b1, b2, b3 = b[..., 0], b[..., 1], b[..., 2], b[..., 3]
+
+        t0 = a01 * a10
+        t1 = a02 * a20
+        t2 = a03 * a30
+        t3 = a23 * a32
+        t4 = a22 + a33
+        t5 = a22 * a33
+        t6 = a12 * a21
+        t7 = a13 * a31
+        t8 = t6 + t7
+        t9 = a12 * a20
+        t10 = a13 * a30
+        t11 = a10 * a11 + t10 + t9
+        t12 = a10 * a21
+        t13 = a23 * a30
+        t14 = a20 * a22 + t12 + t13
+        t15 = a10 * a31
+        t16 = a20 * a32
+        t17 = a30 * a33 + t15 + t16
+        t18 = a23 * a31
+        t19 = a21 * a32
+        t20 = a01 * a12
+        t21 = a03 * a11
+        t22 = a01 * a13
+        t23 = a02 * a33
+        t24 = a03 * a31
+        t25 = a13 * a21
+        t26 = a02 * a23
+        t27 = a00 * a12
+        t28 = a03 * a10
+        t29 = a00 * a13
+        t30 = a11 * a33
+        t31 = a00 * a11
+        t32 = a22 * a30
+        t33 = a02 * a30
+
+        det = (
+            a00
+            * (
+                a11 * (-t3 + t5)
+                + a12 * (a21 * a22 + t18)
+                + a13 * (a31 * a33 + t19)
+                - t4 * t8
+            )
+            - a01 * (a11 * t11 + a12 * t14 + a13 * t17)
+            - a02 * (a21 * t11 + a22 * t14 + a23 * t17)
+            - a03 * (a31 * t11 + a32 * t14 + a33 * t17)
+            + (a11 + t4) * (a01 * t11 + a02 * t14 + a03 * t17)
+            + (t0 + t1 + t2) * (-a11 * t4 + t3 - t5 + t8)
+        )
+        num0 = (
+            b0
+            * (
+                -a11 * t3
+                + a11 * t5
+                + a12 * t18
+                + a13 * t19
+                - a22 * t7
+                - a33 * t6
+            )
+            - b1
+            * (
+                -a01 * t3
+                + a01 * t5
+                + a02 * t18
+                + a03 * t19
+                - a21 * t23
+                - a22 * t24
+            )
+            + b2
+            * (
+                a02 * t7
+                - a11 * t23
+                - a12 * t24
+                + a32 * t21
+                - a32 * t22
+                + a33 * t20
+            )
+            - b3
+            * (
+                a02 * t25
+                - a03 * t6
+                - a11 * t26
+                + a22 * t21
+                - a22 * t22
+                + a23 * t20
+            )
+        )
+        num1 = (
+            -b0
+            * (
+                -a10 * t3
+                + a10 * t5
+                + a12 * t13
+                + a13 * t16
+                - a22 * t10
+                - a33 * t9
+            )
+            + b1
+            * (
+                -a00 * t3
+                + a00 * t5
+                + a02 * t13
+                + a03 * t16
+                - a22 * t2
+                - a33 * t1
+            )
+            - b2
+            * (
+                a02 * t10
+                - a10 * t23
+                - a12 * t2
+                + a32 * t28
+                - a32 * t29
+                + a33 * t27
+            )
+            + b3
+            * (
+                -a03 * t9
+                - a10 * t26
+                + a13 * t1
+                + a22 * t28
+                - a22 * t29
+                + a23 * t27
+            )
+        )
+        num2 = (
+            b0
+            * (
+                -a10 * t18
+                + a11 * t13
+                - a20 * t30
+                + a20 * t7
+                - a21 * t10
+                + a33 * t12
+            )
+            - b1
+            * (
+                a00 * a21 * a33
+                - a00 * t18
+                - a01 * a20 * a33
+                + a01 * t13
+                + a20 * t24
+                - a21 * t2
+            )
+            + b2
+            * (
+                a00 * t30
+                - a00 * t7
+                + a01 * t10
+                + a03 * t15
+                - a11 * t2
+                - a33 * t0
+            )
+            - b3
+            * (
+                -a00 * t25
+                + a03 * t12
+                - a20 * t21
+                + a20 * t22
+                - a23 * t0
+                + a23 * t31
+            )
+        )
+        num3 = (
+            -b0
+            * (
+                a10 * t19
+                - a11 * t16
+                + a11 * t32
+                - a22 * t15
+                - a30 * t6
+                + a31 * t9
+            )
+            + b1
+            * (
+                -a00 * a22 * a31
+                + a00 * t19
+                - a01 * t16
+                + a01 * t32
+                - a21 * t33
+                + a31 * t1
+            )
+            - b2
+            * (
+                a02 * t15
+                - a11 * t33
+                + a30 * t20
+                - a31 * t27
+                - a32 * t0
+                + a32 * t31
+            )
+            + b3
+            * (
+                -a00 * t6
+                + a01 * t9
+                + a02 * t12
+                - a11 * t1
+                - a22 * t0
+                + a22 * t31
+            )
+        )
+        return jnp.stack([num0, num1, num2, num3], axis=-1) / det
+
+    # Fallback for any size not hand-coded.
+    return jnp.linalg.solve(A, b)
+
+
 jax.tree_util.register_pytree_node(
     JittableDict,
     JittableDict._tree_flatten,

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -458,9 +458,9 @@ def pair_distribution_function_SVT_HNC(
             A = A.at[p_idx, q1_idx].add(vals1)
             A = A.at[p_idx, q2_idx].add(vals2)
 
-            # RHS is vec(C) with mapping p = a*M + b matching reshape order
-            rhs = c_k.reshape(-1)
-            H_flat = jnpu.matmul(jnp.linalg.inv(A), rhs)
+            units = c_k.units
+            rhs = c_k.reshape(-1).m_as(units)
+            H_flat = jnp.linalg.solve(A, rhs) * units
 
             return H_flat.reshape((M, M))
 
@@ -572,14 +572,13 @@ def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni, mix=0.0, tmult=None):
         """
         Ornstein-Zernicke Relation
         """
-        return jnpu.matmul(
-            jnp.linalg.inv(
-                (jnp.eye(ni.shape[0]) - jnpu.matmul(input_vec, d)).m_as(
-                    ureg.dimensionless
-                )
-            ),
-            input_vec,
+        A = (jnp.eye(ni.shape[0]) - jnpu.matmul(input_vec, d)).m_as(
+            ureg.dimensionless
         )
+        units = input_vec.units
+        rhs = input_vec.m_as(units)
+        H = jnp.linalg.solve(A, rhs)
+        return H * units
 
     def condition(val):
         """

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -274,9 +274,16 @@ def dst4(f):
 
        Only works if ``len(f)`` is divisible by 2.
 
+
+    .. note::
+
+       Up to a factor of 2, this implementation yields results in agreement
+       with ``scipy.fft.dst(type=4, norm="backward")``
+
+
     See this blogpost for the discrete cosine transform
     https://www.appletonaudio.com/blog/2013/derivation-of-fast-dct-4-algorithm-based-on-dft/
-    To go from the cosine to sine transform, reverse the intputs and flip the
+    To go from the cosine to sine transform, reverse the inputs and flip the
     sign of every other output
     https://en.wikipedia.org/wiki/Discrete_sine_transform
     """

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -270,16 +270,17 @@ def dst4(f):
     (FFT). This is DST type 4. See
     https://en.wikipedia.org/wiki/Discrete_sine_transform
     """
-    window_length = len(f)
-    M = 4 * window_length
-    g = jnp.zeros(M)
-    g = g.at[1 : 2 * window_length : 2].set(f)
-    g = g.at[2 * window_length + 1 : M : 2].set(f[window_length - 1 :: -1])
+    window_length = f.shape[-1]
+    M = 2 * window_length
 
-    n = jnp.arange(M)
-    h = g * jnp.exp(-1j * jnp.pi * n / M)
+    g = jnp.concatenate([f, f[..., ::-1]], axis=-1)
+    m = jnp.arange(M)
+    h = g * jnp.exp(-1j * jnp.pi * m / M)
     H = jnp.fft.fft(h)
-    return -jnp.imag(H[:window_length]) / 2
+
+    j = jnp.arange(window_length)
+    phase = jnp.exp(-1j * jnp.pi * (2 * j + 1) / (2 * M))
+    return -jnp.imag(phase * H[..., :window_length]) / 2
 
 
 _3Dfour_sine = jax.vmap(

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -279,7 +279,7 @@ def zaf_dst(f, dst_type):
         out = jnp.zeros(2 * window_length + 2)
         out = out.at[1 : window_length + 1].set(f)
         out = out.at[window_length + 2 :].set(-f[::-1])
-        out = jnp.fft.fft(out)
+        out = jnp.fft.rfft(out)
         out = -jnp.imag(out[1 : window_length + 1]) / 2
         return out
 
@@ -290,7 +290,7 @@ def zaf_dst(f, dst_type):
         out = out.at[2 * window_length + 1 : 4 * window_length : 2].set(
             -f[-1::-1]
         )
-        out = jnp.fft.fft(out)
+        out = jnp.fft.rfft(out)
         out = -jnp.imag(out[1 : window_length + 1]) / 2
         return out
 
@@ -310,7 +310,7 @@ def zaf_dst(f, dst_type):
         out = out.at[3 * window_length + 1 : 4 * window_length].set(
             -f_copy[-2::-1]
         )
-        out = jnp.fft.fft(out)
+        out = jnp.fft.rfft(out)
         out = -jnp.imag(out[1 : 2 * window_length : 2]) / 4
         return out
 
@@ -326,7 +326,7 @@ def zaf_dst(f, dst_type):
         out = out.at[6 * window_length + 1 : 8 * window_length : 2].set(
             -f[window_length - 1 :: -1]
         )
-        out = jnp.fft.fft(out)
+        out = jnp.fft.rfft(out)
         out = -jnp.imag(out[1 : 2 * window_length : 2]) / 4
         return out
 

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -95,7 +95,7 @@ def fourier_transform_sine(k, rvals, fvals):
     arg = rvals * fvals
     units = arg.units
     dr = rvals[1] - rvals[0]
-    res = zaf_dst(arg.m_as(units), 4) * units * (4 * jnp.pi) / k * dr
+    res = dst4(arg.m_as(units)) * units * (4 * jnp.pi) / k * dr
     return res
 
 
@@ -206,7 +206,6 @@ def realfft(y, isign=1):
         wi = wi * wpr + wtemp * wpi + wi
 
     if isign == 1:
-
         h1r = y[0]
         y = y.at[0].set(h1r + y[1])
         y = y.at[1].set(h1r - y[1])
@@ -263,72 +262,23 @@ def sinft(y):
     return y
 
 
-@partial(jax.jit, static_argnames=["dst_type"])
-def zaf_dst(f, dst_type):
+@partial(jax.jit)
+def dst4(f):
     """
     Compute the discrete sine transform (DST) using the fast Fourier transform
-    (FFT).
-
-    Taken from `Zaf Python
-    <https://github.com/zafarrafii/Zaf-Python/tree/master>`_
+    (FFT). This is DST type 4. See
+    https://en.wikipedia.org/wiki/Discrete_sine_transform
     """
     window_length = len(f)
+    M = 4 * window_length
+    g = jnp.zeros(M)
+    g = g.at[1 : 2 * window_length : 2].set(f)
+    g = g.at[2 * window_length + 1 : M : 2].set(f[window_length - 1 :: -1])
 
-    if dst_type == 1:
-        # Compute the DST-I using the FFT
-        out = jnp.zeros(2 * window_length + 2)
-        out = out.at[1 : window_length + 1].set(f)
-        out = out.at[window_length + 2 :].set(-f[::-1])
-        out = jnp.fft.rfft(out)
-        out = -jnp.imag(out[1 : window_length + 1]) / 2
-        return out
-
-    elif dst_type == 2:
-        # Compute the DST-II using the FFT
-        out = jnp.zeros(4 * window_length)
-        out = out.at[1 : 2 * window_length : 2].set(f)
-        out = out.at[2 * window_length + 1 : 4 * window_length : 2].set(
-            -f[-1::-1]
-        )
-        out = jnp.fft.rfft(out)
-        out = -jnp.imag(out[1 : window_length + 1]) / 2
-        return out
-
-    elif dst_type == 3:
-        # Pre-process the signal to make the DST-III matrix orthogonal
-        # (copy the signal to avoid modifying it outside of the function)
-        f_copy = f.copy()
-        f_copy = f_copy.at[-1].set(f_copy[-1] * jnp.sqrt(2))
-
-        # Compute the DST-III using the FFT
-        out = jnp.zeros(4 * window_length)
-        out = out.at[1 : window_length + 1].set(f_copy)
-        out = out.at[window_length + 1 : 2 * window_length].set(f_copy[-2::-1])
-        out = out.at[2 * window_length + 1 : 3 * window_length + 1].set(
-            -f_copy
-        )
-        out = out.at[3 * window_length + 1 : 4 * window_length].set(
-            -f_copy[-2::-1]
-        )
-        out = jnp.fft.rfft(out)
-        out = -jnp.imag(out[1 : 2 * window_length : 2]) / 4
-        return out
-
-    elif dst_type == 4:
-        out = jnp.zeros(8 * window_length)
-
-        # Compute the DST-IV using the FFT
-        out = out.at[1 : 2 * window_length : 2].set(f)
-        out = out.at[2 * window_length + 1 : 4 * window_length : 2].set(
-            f[window_length - 1 :: -1]
-        )
-        out = out.at[4 * window_length + 1 : 6 * window_length : 2].set(-f)
-        out = out.at[6 * window_length + 1 : 8 * window_length : 2].set(
-            -f[window_length - 1 :: -1]
-        )
-        out = jnp.fft.rfft(out)
-        out = -jnp.imag(out[1 : 2 * window_length : 2]) / 4
-        return out
+    n = jnp.arange(M)
+    h = g * jnp.exp(-1j * jnp.pi * n / M)
+    H = jnp.fft.fft(h)
+    return -jnp.imag(H[:window_length]) / 2
 
 
 _3Dfour_sine = jax.vmap(
@@ -410,7 +360,6 @@ def pair_distribution_function_SVT_HNC(
         return coeff1, coeff2
 
     for titer, mult in enumerate(tmult):
-
         beta = 1 / (ureg.boltzmann_constant * mult * T_ab)
 
         v_s = beta * V_s

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -10,7 +10,8 @@ import jax.interpreters
 import jpu.numpy as jnpu
 from jax import numpy as jnp
 
-from jaxrts.units import Quantity, ureg
+from .units import Quantity, ureg
+from .helpers import cramer_solve
 
 
 # Helper functions.
@@ -306,9 +307,17 @@ _3Dfour_ogata = jax.vmap(
 _3Dfour = _3Dfour_sine
 
 
-@jax.jit
+@partial(jax.jit, static_argnames=["cramer_solve_max_size"])
 def pair_distribution_function_SVT_HNC(
-    V_s, V_l_k, r, T_ab, n, m, mix=0.0, tmult=None
+    V_s,
+    V_l_k,
+    r,
+    T_ab,
+    n,
+    m,
+    mix=0.0,
+    tmult=None,
+    cramer_solve_max_size: int = 4,
 ):
     """
     Multi-component, multi-temperature version of the SVT-OZ-HNC, by extending
@@ -332,7 +341,10 @@ def pair_distribution_function_SVT_HNC(
 
     @jax.jit
     def build_coeffs(
-        n: jnp.ndarray, T: jnp.ndarray, m: jnp.ndarray, mab: jnp.ndarray
+        n: jnp.ndarray,
+        T: jnp.ndarray,
+        m: jnp.ndarray,
+        mab: jnp.ndarray,
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         """
         n: (M,), T: (M,M) pairwise array, m: (M,)
@@ -409,7 +421,7 @@ def pair_distribution_function_SVT_HNC(
 
             units = c_k.units
             rhs = c_k.reshape(-1).m_as(units)
-            H_flat = jnp.linalg.solve(A, rhs) * units
+            H_flat = cramer_solve(A, rhs, cramer_solve_max_size) * units
 
             return H_flat.reshape((M, M))
 
@@ -481,8 +493,10 @@ def pair_distribution_function_SVT_HNC(
     return jnpu.exp(log_g_r), niter
 
 
-@jax.jit
-def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni, mix=0.0, tmult=None):
+@partial(jax.jit, static_argnames=["cramer_solve_max_size"])
+def pair_distribution_function_HNC(
+    V_s, V_l_k, r, Ti, ni, mix=0.0, tmult=None, cramer_solve_max_size=4
+):
     """
     Calculate the Pair distribution function in the Hypernetted Chain approach,
     as it was published by :cite:`Wunsch.2011`.
@@ -526,7 +540,7 @@ def pair_distribution_function_HNC(V_s, V_l_k, r, Ti, ni, mix=0.0, tmult=None):
         )
         units = input_vec.units
         rhs = input_vec.m_as(units)
-        H = jnp.linalg.solve(A, rhs)
+        H = cramer_solve(A, rhs, cramer_solve_max_size)
         return H * units
 
     def condition(val):

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -386,38 +386,27 @@ def pair_distribution_function_SVT_HNC(
             """
             The modified Ornstein-Zernicke Relation
             """
-
             M = c_k.shape[0]
-            ar = jnp.arange(M)
 
-            # index grids
-            a = ar[:, jnp.newaxis, jnp.newaxis]  # shape (M,1,1)
-            b = ar[jnp.newaxis, :, jnp.newaxis]  # shape (1,M,1)
-            s = ar[jnp.newaxis, jnp.newaxis, :]  # shape (1,1,M)
+            term1 = coeff_1 * c_k[:, jnp.newaxis, :]
+            term2 = coeff_2 * c_k.T[jnp.newaxis, :, :]
 
-            # broadcast to full (M,M,M) so every (a,b,s) is explicit
-            a3 = jnp.broadcast_to(a, (M, M, M))
-            b3 = jnp.broadcast_to(b, (M, M, M))
-            s3 = jnp.broadcast_to(s, (M, M, M))
+            vals1 = -term1.m_as(ureg.dimensionless)
+            vals2 = -term2.m_as(ureg.dimensionless)
 
-            # flattened row & column indices in the big matrix A
-            p_idx = (a3 * M + b3).reshape(-1).astype(jnp.int32)  # (M^3,)
-            q1_idx = (s3 * M + b3).reshape(-1).astype(jnp.int32)  # idx(s,b)
-            q2_idx = (a3 * M + s3).reshape(-1).astype(jnp.int32)  # idx(a,s)
+            eye_M = jnp.eye(M, dtype=c_k.dtype)
+            # vals1[a,b,s] belongs at A[(a,b),(s,b)]
+            A1 = (
+                vals1[:, :, :, jnp.newaxis]
+                * eye_M[jnp.newaxis, :, jnp.newaxis, :]
+            ).reshape(M * M, M * M)
+            # vals2[a,b,s] belongs at A[(a,b),(a,s)]
+            A2 = (
+                vals2[:, :, jnp.newaxis, :]
+                * eye_M[:, jnp.newaxis, :, jnp.newaxis]
+            ).reshape(M * M, M * M)
 
-            # values to scatter:
-            # -alpha[a,b,s] * C[a,s] and -beta[a,b,s] * C[s,b]
-            vals1 = (
-                -(coeff_1 * c_k[a3, s3]).reshape(-1).m_as(ureg.dimensionless)
-            )
-            vals2 = (
-                -(coeff_2 * c_k[s3, b3]).reshape(-1).m_as(ureg.dimensionless)
-            )
-
-            # Build A = I + scattered contributions
-            A = jnp.eye(M**2, dtype=c_k.dtype)
-            A = A.at[p_idx, q1_idx].add(vals1)
-            A = A.at[p_idx, q2_idx].add(vals2)
+            A = jnp.eye(M**2, dtype=c_k.dtype) + A1 + A2
 
             units = c_k.units
             rhs = c_k.reshape(-1).m_as(units)

--- a/src/jaxrts/hypernetted_chain.py
+++ b/src/jaxrts/hypernetted_chain.py
@@ -269,18 +269,41 @@ def dst4(f):
     Compute the discrete sine transform (DST) using the fast Fourier transform
     (FFT). This is DST type 4. See
     https://en.wikipedia.org/wiki/Discrete_sine_transform
+
+    .. warning::
+
+       Only works if ``len(f)`` is divisible by 2.
+
+    See this blogpost for the discrete cosine transform
+    https://www.appletonaudio.com/blog/2013/derivation-of-fast-dct-4-algorithm-based-on-dft/
+    To go from the cosine to sine transform, reverse the intputs and flip the
+    sign of every other output
+    https://en.wikipedia.org/wiki/Discrete_sine_transform
     """
-    window_length = f.shape[-1]
-    M = 2 * window_length
+    N = f.shape[-1]
+    M = N // 2
 
-    g = jnp.concatenate([f, f[..., ::-1]], axis=-1)
-    m = jnp.arange(M)
-    h = g * jnp.exp(-1j * jnp.pi * m / M)
-    H = jnp.fft.fft(h)
+    # Flip the input
+    c = f[..., ::-1]
+    i_arr = jnp.arange(M)
+    fac = jnp.exp(-1j * jnp.pi * (i_arr + 1 / 8) / N)
 
-    j = jnp.arange(window_length)
-    phase = jnp.exp(-1j * jnp.pi * (2 * j + 1) / (2 * M))
-    return -jnp.imag(phase * H[..., :window_length]) / 2
+    y = (c[..., 2 * i_arr] + 1j * c[..., N - 1 - 2 * i_arr]) * fac
+    Y = jnp.fft.fft(y)
+
+    Y *= fac
+
+    ic = M - 1 - i_arr
+    even = Y[..., i_arr].real
+    odd = -Y[..., ic].imag
+
+    out = jnp.zeros(f.shape)
+    out = out.at[..., 2 * i_arr].set(even)
+    out = out.at[..., 2 * i_arr + 1].set(odd)
+
+    # Flip the sign every other output
+    out = out.at[..., 1::2].multiply(-1)
+    return out
 
 
 _3Dfour_sine = jax.vmap(

--- a/src/jaxrts/models.py
+++ b/src/jaxrts/models.py
@@ -764,6 +764,7 @@ class OnePotentialHNCIonFeat(IonFeatModel):
         SVT: bool = False,
         mix: float = 0.0,
         tmult: list[float] = None,
+        cramer_solve_max_size: int = 4,
     ) -> None:
         #: The minimal radius for evaluating the potentials.
         if tmult is None:
@@ -792,6 +793,10 @@ class OnePotentialHNCIonFeat(IonFeatModel):
         #: See also
         #: :py:func:`jaxrts.hypernetted_chain.pair_distribution_function_HNC`.
         self.tmult: list[float] = tmult
+        #: The maximum matrix size for which the direct matrix inverison sould
+        #: be used over `jnp.linalg.solve` in the SVT algorighm. See also
+        #: `:py:func:`jaxrts.helpers.cramer_solve`.
+        self.cramer_solve_max_size: int = cramer_solve_max_size
         super().__init__()
 
     def prepare(self, plasma_state: "PlasmaState", key: str) -> None:
@@ -828,11 +833,26 @@ class OnePotentialHNCIonFeat(IonFeatModel):
         if self.SVT:
             masses = to_array([ion.atomic_mass for ion in plasma_state.ions])
             g, niter = hypernetted_chain.pair_distribution_function_SVT_HNC(
-                V_s_r, V_l_k, self.r, T, n, masses, self.mix, self.tmult
+                V_s_r,
+                V_l_k,
+                self.r,
+                T,
+                n,
+                masses,
+                self.mix,
+                self.tmult,
+                self.cramer_solve_max_size,
             )
         else:
             g, niter = hypernetted_chain.pair_distribution_function_HNC(
-                V_s_r, V_l_k, self.r, T, n, self.mix, self.tmult
+                V_s_r,
+                V_l_k,
+                self.r,
+                T,
+                n,
+                self.mix,
+                self.tmult,
+                self.cramer_solve_max_size,
             )
         logger.debug(
             f"{niter} Iterations of the HNC algorithm were required to reach the solution"  # noqa: E501
@@ -854,13 +874,14 @@ class OnePotentialHNCIonFeat(IonFeatModel):
             self.model_key,
             self.pot,
             self.SVT,
+            self.cramer_solve_max_size,
         )  # static values
         return (children, aux_data)
 
     @classmethod
     def _tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
-        obj.model_key, obj.pot, obj.SVT = aux_data
+        obj.model_key, obj.pot, obj.SVT, obj.cramer_solve_max_size = aux_data
         obj.r_min, obj.r_max, obj.mix, obj.tmult = children
 
         return obj

--- a/tests/saves/state.json
+++ b/tests/saves/state.json
@@ -251,7 +251,8 @@
               [
                 "ionic scattering",
                 14,
-                false
+                false,
+                4
               ]
             ]
           ]

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,4 +1,6 @@
+import jax
 from jax import numpy as jnp
+from scipy.fft import dst as scipy_dst
 
 import jaxrts
 
@@ -27,3 +29,38 @@ def test_fukushima_inversion():
         )
         < 0.001
     )
+
+
+def test_cramer_solve():
+    Ngrid = 4096
+
+    key = jax.random.PRNGKey(42534252356534)
+    for M in [1, 2, 3, 4]:
+        for _ in range(50):
+            key, loopkey1, loopkey2 = jax.random.split(key, 3)
+            # start with diagonal matrix to avoid ill-posed problems
+            A = jnp.eye(M) * jax.random.normal(loopkey1, (Ngrid, M, M))
+            b = jax.random.normal(loopkey2, (Ngrid, M))
+
+            ref = jax.vmap(lambda Ai, bi: jnp.linalg.solve(Ai, bi))(A, b)
+            got = jax.vmap(jaxrts.helpers.cramer_solve)(A, b)
+            err = float(jnp.max(jnp.abs(ref - got)))
+            assert err < 1e-8, f"Error for inverting {M}"
+
+
+def test_dst_against_scipy():
+    Ngrid = 4096
+
+    key = jax.random.PRNGKey(894148965434567)
+    for _ in range(500):
+        (
+            key,
+            loopkey1,
+        ) = jax.random.split(key, 2)
+        f = jax.random.normal(loopkey1, (Ngrid,))
+
+        # Our norm is slightly different
+        ref = scipy_dst(f, type=4) / 2
+        got = jaxrts.hypernetted_chain.dst4(f)
+        err = float(jnp.mean(jnp.abs(ref - got)))
+        assert err < 1e-12


### PR DESCRIPTION
This collection of commits should increase the performance of HNC calculations quite notably, both for compilation and execution time. It mainly does 3 things:

1. The discrete sine transform algorithm now uses way shorter internal arrays.
2. We don't use `jaxrts.linalg.inv` for the matrix inversion, anymore. Instead, for small matrices, the inversion is hard-coded, and for big ones, we use `jaxrts.linalg.solve`. The hand-written inversion might lead to errors for ill-posed matrices. The risk is increasing with matrix size; therefore, I allow users to set the limit for the switch by hand. I have, however, not faced issues doing my testing. Please note that I've asked AI to spell write the `cramers_solve` using sympy. See attached the [generation script](https://github.com/user-attachments/files/29697435/gen-cramers-solve.py) for documentation and review. In the tests, I provide a test of the result for reasonably well-behaving matrices.
3. Simplify the construction of internal matrices for SVT-HNC