### PR TITLE
Instrument function objects

### DIFF
--- a/doc/examples/analysis/plot_ITCFT.py
+++ b/doc/examples/analysis/plot_ITCFT.py
@@ -7,8 +7,6 @@ from the Laplace transform of the structure, as proposed by
 :cite:`Dornheim.2022`.
 """
 
-from functools import partial
-
 import jax
 import matplotlib.pyplot as plt
 from jax import numpy as jnp
@@ -31,10 +29,7 @@ setup = jaxrts.Setup(
     energy=ureg("9000 eV"),
     measured_energy=ureg("9000 eV")
     + jnp.linspace(-200, 200, 500) * ureg.electron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("3eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("3.0eV")),
 )
 
 # Turn off the dispersion correction

--- a/doc/examples/analysis/plot_ITCFT_noise.py
+++ b/doc/examples/analysis/plot_ITCFT_noise.py
@@ -6,8 +6,6 @@ In this example, we apply the ITCFT to increasingly noisy data with different
 scattering angles.
 """
 
-from functools import partial
-
 import jax
 import matplotlib.pyplot as plt
 import scienceplots  # noqa: F401
@@ -41,10 +39,7 @@ for angle, e_range in [[120, 600], [20, 200]]:
         energy=ureg("9000 eV"),
         measured_energy=ureg("9000 eV")
         + jnp.linspace(-e_range, e_range, 1000) * ureg.electron_volt,
-        instrument=partial(
-            jaxrts.instrument_function.instrument_gaussian,
-            sigma=ureg("3eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-        ),
+        instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("3.0eV")),
     )
 
     # Turn off the dispersion correction

--- a/doc/examples/analysis/plot_f-sum-rule.py
+++ b/doc/examples/analysis/plot_f-sum-rule.py
@@ -13,8 +13,6 @@ could leverage this to fix a value for
 fulfilled.
 """
 
-from functools import partial
-
 import jax
 import matplotlib.pyplot as plt
 from jax import numpy as jnp
@@ -36,10 +34,7 @@ setup = jaxrts.Setup(
     energy=ureg("9 keV"),
     measured_energy=ureg("9 keV")
     + jnp.linspace(-2000, 2000, 5000) * ureg.electron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("5eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("5.0eV")),
 )
 
 # Turn off the dispersion correction

--- a/doc/examples/bound_free/plot_edge_models.py
+++ b/doc/examples/bound_free/plot_edge_models.py
@@ -6,8 +6,6 @@ This example showcases different edge-models that can be used in the bound free
 scattering features.
 """
 
-from functools import partial
-
 import matplotlib.pyplot as plt
 
 # jax provides a submodule which can be (mostly) used as a drop-in replacement
@@ -41,10 +39,7 @@ setup = jaxrts.Setup(
     energy=ureg("8700 eV"),
     measured_energy=ureg("8700 eV")
     + jnp.linspace(-550, 40, 500) * ureg.electron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("5.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("5.0eV")),
 )
 
 

--- a/doc/examples/bound_free/plot_moving_edges_vs_cold.py
+++ b/doc/examples/bound_free/plot_moving_edges_vs_cold.py
@@ -81,11 +81,8 @@ setup = jaxrts.Setup(
     scattering_angle=ureg(f"{scattering_angle} deg"),  # Explicit units
     energy=ureg(f"{photon_energy} keV"),
     measured_energy=measured_energy,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg(f"{source_fwhm}eV")
-        / ureg.hbar
-        / (2 * jnp.sqrt(2 * jnp.log(2))),
+    instrument=jaxrts.instrument_function.Gaussian(
+        fwhm=ureg(f"{source_fwhm}eV")
     ),
 )
 state["ipd"] = jaxrts.models.StewartPyattIPD()

--- a/doc/examples/free_bound/plot_free_bound_scattering.py
+++ b/doc/examples/free_bound/plot_free_bound_scattering.py
@@ -8,8 +8,6 @@ However, we used simpler for the relevant scattering processes, just to show
 the usage of :py:class:`jaxrts.models.DetailedBalace`.
 """
 
-from functools import partial
-
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
@@ -23,10 +21,7 @@ setup = jaxrts.setup.Setup(
     ureg("120°"),
     energy=ureg("9keV"),
     measured_energy=jnp.linspace(8, 9.5, 300) * ureg.kiloelectron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=(30.0 * ureg.electron_volt) / ureg.hbar,
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(sigma=ureg("30.0eV")),
 )
 state = jaxrts.PlasmaState(
     [jaxrts.Element("Be")],

--- a/doc/examples/free_free/plot_BM_ChapmanInterp.py
+++ b/doc/examples/free_free/plot_BM_ChapmanInterp.py
@@ -21,7 +21,6 @@ to be higher for comparable quality of the result, when using ``KKT``.
 
 import os
 import time
-from functools import partial
 
 import jax
 import jax.numpy as jnp
@@ -44,10 +43,7 @@ setup = jaxrts.setup.Setup(
     ureg("60°"),
     energy=ureg("300eV"),
     measured_energy=measured_energy,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=(0.01 * ureg.electron_volt) / ureg.hbar,
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("0.01eV")),
 )
 state = jaxrts.PlasmaState(
     [jaxrts.Element("H")],

--- a/doc/examples/ionization/plot_WR_expanded_ionization.py
+++ b/doc/examples/ionization/plot_WR_expanded_ionization.py
@@ -10,8 +10,6 @@ called which creates a plasma state with two ion species of the same element,
 but different ionization numbers. The latter calculation will be more costly.
 """
 
-from functools import partial
-
 import jax
 import matplotlib.pyplot as plt
 from jax import numpy as jnp
@@ -35,10 +33,7 @@ setup = jaxrts.Setup(
     energy=ureg("8000 eV"),
     measured_energy=ureg("8000 eV")
     + jnp.linspace(-100, 40, 500) * ureg.electron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("5.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("5.0eV")),
 )
 
 

--- a/doc/examples/plot_getting_started.py
+++ b/doc/examples/plot_getting_started.py
@@ -6,8 +6,6 @@ This example showcases a simple, one-component plasma, and might be a good
 starting point.
 """
 
-from functools import partial
-
 import matplotlib.pyplot as plt
 
 # jax provides a submodule which can be (mostly) used as a drop-in replacement
@@ -38,10 +36,7 @@ setup = jaxrts.Setup(
     energy=ureg("4700 eV"),
     measured_energy=ureg("4700 eV")
     + jnp.linspace(-100, 40, 500) * ureg.electron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("5.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("5.0eV")),
 )
 
 # Add Models. In the typical way, we use the Chihara decomposition in the code,

--- a/doc/examples/plot_multi_component.py
+++ b/doc/examples/plot_multi_component.py
@@ -5,8 +5,6 @@ Multi-Species Plasmas
 This example calculates a synthetic spectrum of a CHO plasma.
 """
 
-from functools import partial
-
 import matplotlib.pyplot as plt
 from jax import numpy as jnp
 
@@ -36,10 +34,7 @@ setup = jaxrts.Setup(
     scattering_angle=ureg("150°"),
     energy=ureg("8 keV"),
     measured_energy=jnp.linspace(7.4, 8.2, 500) * ureg.kiloelectron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("7.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("7.0eV")),
 )
 
 # Add the required models

--- a/doc/examples/setup/plot_frequency_redistibution_correction.py
+++ b/doc/examples/setup/plot_frequency_redistibution_correction.py
@@ -9,8 +9,6 @@ This example shows how the frequency redistribution correction
 For a discussion, see :cite:`Crowley.2013`.
 """
 
-from functools import partial
-
 import matplotlib.pyplot as plt
 from jax import numpy as jnp
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
@@ -31,10 +29,7 @@ setup = jaxrts.Setup(
     energy=ureg("8700 eV"),
     measured_energy=ureg("8700 eV")
     + jnp.linspace(-666, 100, 500) * ureg.electron_volt,
-    instrument=partial(
-        jaxrts.instrument_function.instrument_gaussian,
-        sigma=ureg("5.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-    ),
+    instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("5.0eV")),
 )
 
 state["ionic scattering"] = jaxrts.models.OnePotentialHNCIonFeat()

--- a/doc/examples/utils/plot_instrument_function_models.py
+++ b/doc/examples/utils/plot_instrument_function_models.py
@@ -27,19 +27,17 @@ width = 20 * ureg.electron_volt / ureg.hbar
 
 plt.plot(
     E.m_as(ureg.electron_volt),
-    ifs.instrument_gaussian(w, width).m_as(ureg.hbar / ureg.electron_volt),
+    ifs.Gaussian(width)(w).m_as(ureg.hbar / ureg.electron_volt),
     label="Gaussian Model",
 )
 plt.plot(
     E.m_as(ureg.electron_volt),
-    ifs.instrument_supergaussian(w, width, 2).m_as(
-        ureg.hbar / ureg.electron_volt
-    ),
+    ifs.SuperGaussian(2, width)(w).m_as(ureg.hbar / ureg.electron_volt),
     label="Super-Gaussian Model (p=2)",
 )
 plt.plot(
     E.m_as(ureg.electron_volt),
-    ifs.instrument_lorentzian(w, width).m_as(ureg.hbar / ureg.electron_volt),
+    ifs.Lorentzian(width)(w).m_as(ureg.hbar / ureg.electron_volt),
     label="Lorentzian Model",
 )
 

--- a/doc/source/first-spectrum.rst
+++ b/doc/source/first-spectrum.rst
@@ -24,7 +24,6 @@ First, import the relevant packages:
 
 .. code:: python
 
-    from functools import partial
     import matplotlib.pyplot as plt
     from jax import numpy as jnp
     import jaxrts
@@ -47,7 +46,7 @@ instance; its application should be clear after reading this example.
 We rely on `jpu <https://github.com/dfm/jpu>`_, a port of `pint
 <https://pint.readthedocs.io>`_ to the jax ecosystem.
 
-With this out of the way, we lets the define a two-times ionized beryllium
+With this out of the way, let's define a two-times ionized beryllium
 plasma at :math:`\rho=1\text{g/cc}` and an electron temperature :math:`k_BT_e =
 1\text{eV}`.
 
@@ -87,7 +86,7 @@ As we can see we have set densities, ionization, and temperature, as well as
 some default models.
 
 Next, we also have to define a :py:class:`jaxrts.setup.Setup`. :py:mod:`jpu`
-also allows to convert string to quantities with units, as you can see below.
+also allows converting string to quantities with units, as you can see below.
 
 .. code:: python
 
@@ -96,10 +95,7 @@ also allows to convert string to quantities with units, as you can see below.
         energy=ureg("4700 eV"),
         measured_energy=ureg("4700 eV")
         + jnp.linspace(-100, 40, 500) * ureg.electron_volt,
-        instrument=partial(
-            jaxrts.instrument_function.instrument_gaussian,
-            sigma=ureg("5.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-        ),
+        instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("5.0eV")),
     )
 
 

--- a/src/jaxrts/__init__.py
+++ b/src/jaxrts/__init__.py
@@ -33,7 +33,11 @@ from .plasmastate import PlasmaState
 from .setup import Setup
 from .units import ureg
 
-from .collections import get_all_models, get_all_models_list
+from .collections import (
+    get_all_models,
+    get_all_models_list,
+    get_all_instrument_functions,
+)
 
 __all__ = [
     "Element",
@@ -71,10 +75,11 @@ __all__ = [
 import jax
 
 _all_models = get_all_models_list()
+_all_instrument_functions = get_all_instrument_functions()
 
-for _model in _all_models:
+for _obj in [*_all_models, *_all_instrument_functions]:
     jax.tree_util.register_pytree_node(
-        _model,
-        _model._tree_flatten,
-        _model._tree_unflatten,
+        _obj,
+        _obj._tree_flatten,
+        _obj._tree_unflatten,
     )

--- a/src/jaxrts/collections.py
+++ b/src/jaxrts/collections.py
@@ -8,7 +8,7 @@ This is a submodule of its own to avoid circular imports.
 from collections import defaultdict
 from typing import overload, Dict, Literal
 import inspect
-from . import hnc_potentials, models
+from . import hnc_potentials, models, instrument_function
 
 
 @overload
@@ -76,6 +76,52 @@ def get_all_models(
                         else:
                             all_models[k].append(obj)
     return all_models
+
+
+@overload
+def get_all_instrument_functions(
+    names_only: Literal[False] = False,
+) -> list[instrument_function.InstrumentFunction]: ...
+@overload
+def get_all_instrument_functions(
+    names_only: Literal[True],
+) -> list[str]: ...
+def get_all_instrument_functions(
+    names_only: bool = False,
+) -> list[instrument_function.InstrumentFunction | str]:
+    """
+    Get a list of all :py:class:`jaxrts.instrument_function.InstrumentFunction`
+    defined within jaxrts.
+
+    Parameters
+    ----------
+    names_only: bool, default False
+        If ``true``, the values of the returned dict are a list of
+        :py:class:`jaxrts.models.Model` object. If false, the values are rather
+        list of strings with of the name of the models.
+
+    Returns
+    -------
+    List of all instrument functions available in jaxrts.
+    """
+    all_inst_funcs = []
+    for instrument_name in dir(instrument_function):
+        if "__class__" in dir(instrument_name):
+            obj = getattr(instrument_function, instrument_name)
+            # The model must be concrete (cannot be abstract), has to
+            # advertise allowed keys, and cannot have a private name that
+            # starts with ``_``.
+            if (
+                not inspect.isabstract(obj)
+                and inspect.isclass(obj)
+                and issubclass(obj, instrument_function.InstrumentFunction)
+                and not instrument_name.startswith("_")
+            ):
+                if names_only:
+                    all_inst_funcs.append(instrument_name)
+                else:
+                    all_inst_funcs.append(obj)
+    return all_inst_funcs
 
 
 @overload

--- a/src/jaxrts/instrument_function.py
+++ b/src/jaxrts/instrument_function.py
@@ -4,6 +4,7 @@ functions.
 """
 
 import abc
+import functools
 
 import logging
 from collections.abc import Callable
@@ -181,31 +182,63 @@ class Lorentzian(InstrumentFunction):
 
 
 class FromCallable(InstrumentFunction):
-    def __init__(self, function: callable):
+    def __init__(self, function):
         """
         Create an :py:class`~.InstrumentFunction` from a callable.
+
+        If ``function`` is a ``functools.partial``, its bound positional and
+        keyword arguments are unpacked and re-flattened as genuine pytree
+        leaves.
         """
-        self.function = jax.tree_util.Partial(function)
+        if isinstance(function, functools.partial):
+            self.function = function.func
+            self.partial_args = function.args
+            self.partial_kwargs = function.keywords
+        else:
+            self.function = function
+            self.partial_args = ()
+            self.partial_kwargs = {}
 
     def __call__(self, omega):
-        return self.function(omega)
+        # Bound positional args come before the call-time argument.
+        return self.function(*self.partial_args, omega, **self.partial_kwargs)
 
     def _tree_flatten(self):
-        children = ()
-        aux_data = (self.function,)  # static values
-        return (children, aux_data)
+        args_leaves, args_treedef = jax.tree_util.tree_flatten(
+            self.partial_args
+        )
+        kwargs_leaves, kwargs_treedef = jax.tree_util.tree_flatten(
+            self.partial_kwargs
+        )
+        children = tuple(args_leaves) + tuple(kwargs_leaves)
+        aux_data = (
+            self.function,
+            len(args_leaves),
+            args_treedef,
+            kwargs_treedef,
+        )
+        return children, aux_data
 
     @classmethod
     def _tree_unflatten(cls, aux_data, children):
+        func, n_args_leaves, args_treedef, kwargs_treedef = aux_data
+        args_leaves = children[:n_args_leaves]
+        kwargs_leaves = children[n_args_leaves:]
         obj = object.__new__(cls)
-        (obj.function,) = aux_data
+        obj.function = func
+        obj.partial_args = jax.tree_util.tree_unflatten(
+            args_treedef, args_leaves
+        )
+        obj.partial_kwargs = jax.tree_util.tree_unflatten(
+            kwargs_treedef, kwargs_leaves
+        )
         return obj
 
 
 class FromArray(InstrumentFunction):
     def __init__(self, x, ints):
         """
-        Set instrument function from an array input.
+        Generate an InstrumentFunction from an array input.
         The intensities ``I`` have to have the same length as the energy shift
         ``x``.
 

--- a/src/jaxrts/instrument_function.py
+++ b/src/jaxrts/instrument_function.py
@@ -204,15 +204,21 @@ class Lorentzian(InstrumentFunction):
 
 
 class FromCallable(InstrumentFunction):
-    def __init__(self, function):
+    def __init__(self, function, disable_partial_unwrapping: bool = False):
         """
         Create an :py:class`~.InstrumentFunction` from a callable.
 
         If ``function`` is a ``functools.partial``, its bound positional and
         keyword arguments are unpacked and re-flattened as genuine pytree
-        leaves.
+        leaves. This requires that tracing though all positional and keyword
+        arguments is possible. If this is not the case, define a new function
+        where this is the case, or set the flag
+        "disable_partial_unwrapping==True".
         """
-        if isinstance(function, functools.partial):
+        if (
+            isinstance(function, functools.partial)
+            and not disable_partial_unwrapping
+        ):
             _check_callable_for_deprication(function.func)
             self.function = function.func
             self.partial_args = function.args

--- a/src/jaxrts/instrument_function.py
+++ b/src/jaxrts/instrument_function.py
@@ -149,7 +149,7 @@ class SuperGaussian(InstrumentFunction):
         return self.sigma * (2 * jnp.sqrt(2 * jnp.log(2)))
 
     def __call__(self, omega):
-        return instrument_supergaussian(omega, self.power, self.sigma)
+        return instrument_supergaussian(omega, self.sigma, self.power)
 
     _children_labels = ("sigma", "power")
 

--- a/src/jaxrts/instrument_function.py
+++ b/src/jaxrts/instrument_function.py
@@ -9,6 +9,7 @@ import functools
 import logging
 from collections.abc import Callable
 from pathlib import Path
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -18,6 +19,27 @@ import numpy as onp
 from .units import Quantity, Unit, ureg
 
 logger = logging.getLogger(__name__)
+
+
+def _check_callable_for_deprication(func: Callable) -> None:
+    """
+    Issue deprecation warnings if old functions are used in
+    :py:class:`~.FromCallable`.
+    """
+    alternatives = {
+        "instrument_gaussian": "Gaussian",
+        "instrument_supergaussian": "SuperGaussian",
+        "instrument_lorentzian": "Lorentzian",
+    }
+    if func.__name__ in alternatives.keys():
+        warnings.warn(
+            f"Passing ``{func.__name__}`` as an instrument function "
+            "to ``FromCallable`` is deprecated. Instead "
+            f"jaxrts.instrument_function.{alternatives[func.__name__]}() "
+            "should be used.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
 
 class InstrumentFunction(metaclass=abc.ABCMeta):
@@ -191,10 +213,12 @@ class FromCallable(InstrumentFunction):
         leaves.
         """
         if isinstance(function, functools.partial):
+            _check_callable_for_deprication(function.func)
             self.function = function.func
             self.partial_args = function.args
             self.partial_kwargs = function.keywords
         else:
+            _check_callable_for_deprication(function)
             self.function = function
             self.partial_args = ()
             self.partial_kwargs = {}

--- a/src/jaxrts/instrument_function.py
+++ b/src/jaxrts/instrument_function.py
@@ -3,6 +3,8 @@ This submodule is dedicated to the modelling and handling of instrument
 functions.
 """
 
+import abc
+
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -15,6 +17,237 @@ import numpy as onp
 from .units import Quantity, Unit, ureg
 
 logger = logging.getLogger(__name__)
+
+
+class InstrumentFunction(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def __call__(self, omega: Quantity) -> Quantity: ...
+
+
+class Gaussian(InstrumentFunction):
+    def __init__(
+        self, sigma: Quantity | None = None, fwhm: Quantity | None = None
+    ):
+        """
+        Gaussian instrument function
+
+        .. math::
+
+           \\frac{1}{\\sigma \\sqrt{2\\pi}}
+           \\exp\\left(-\\frac{x^2}{{2\\sigma}^2}\\right)
+
+
+        Parameters
+        ----------
+        sigma: Quantity, optional
+            The parameter sigma, the standard deviation of the gaussian. must
+            be given in units of energy or frequency.
+        fwhm: Quantity, optional
+            The full width half maximum of the distribution.
+
+        Raises
+        ------
+        TypeError if neither ``sigma`` nor ``fwhm`` are given.
+        """
+        if sigma is None and fwhm is None:
+            raise TypeError("Either sigma or fwhm have to be supplied.")
+        if fwhm is not None:
+            sigma = fwhm / (2 * jnp.sqrt(2 * jnp.log(2)))
+        if sigma.check("[energy]"):
+            sigma = sigma / (1 * ureg.hbar)
+        self.sigma = sigma
+
+    @property
+    def fwhm(self):
+        return self.sigma * (2 * jnp.sqrt(2 * jnp.log(2)))
+
+    def __call__(self, omega):
+        return instrument_gaussian(omega, self.sigma)
+
+    _children_labels = ("sigma",)
+
+    def _tree_flatten(self):
+        children = (self.sigma,)
+        aux_data = ()  # static values
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        (obj.sigma,) = children
+
+        return obj
+
+
+class SuperGaussian(InstrumentFunction):
+    def __init__(
+        self,
+        power,
+        sigma: Quantity | None = None,
+        fwhm: Quantity | None = None,
+    ):
+        """
+        Supergaussian instrument function
+
+        .. math::
+
+           \\exp\\left(-\\left(\\frac{x^2}{2\\sigma^2}\\right)^p\\right)
+
+        .. note::
+
+           The function is normalized by numerical integration
+
+        Parameters
+        ----------
+        power: float
+            The exponent p in above equation.
+        sigma: Quantity, optional
+            The parameter sigma (must be given in units of energy or
+            frequency.
+        fwhm: Quantity, optional
+            The full width half maximum of the distribution.
+
+        Raises
+        ------
+        TypeError if neither ``sigma`` nor ``fwhm`` are given.
+
+        """
+        if sigma is None and fwhm is None:
+            raise TypeError("Either sigma or fwhm have to be supplied.")
+        if fwhm is not None:
+            sigma = fwhm / (2 * jnp.sqrt(2 * jnp.log(2)))
+        if sigma.check("[energy]"):
+            sigma = sigma / (1 * ureg.hbar)
+        self.sigma = sigma
+        self.power = power
+
+    @property
+    def fwhm(self):
+        return self.sigma * (2 * jnp.sqrt(2 * jnp.log(2)))
+
+    def __call__(self, omega):
+        return instrument_supergaussian(omega, self.power, self.sigma)
+
+    _children_labels = ("sigma", "power")
+
+    def _tree_flatten(self):
+        children = self.sigma, self.power
+        aux_data = ()  # static values
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        (obj.sigma, obj.power) = children
+        return obj
+
+
+class Lorentzian(InstrumentFunction):
+    def __init__(self, gamma):
+        """
+        Lorentzian model for the instrument function.
+
+        .. math::
+
+           \\frac{1}{\\pi}
+           \\frac{1}
+           {\\gamma \\left(1+\\left(\\frac{x}{\\gamma}\\right)^2\\right)}
+
+
+        Parameters
+        ----------
+        gamma: Quantity
+            The scale parameter of the lorentzian.
+        """
+        if gamma.check("[energy]"):
+            gamma = gamma / (1 * ureg.hbar)
+        self.gamma = gamma
+
+    def __call__(self, omega):
+        return instrument_lorentzian(omega, self.gamma)
+
+    def _tree_flatten(self):
+        children = (self.gamma,)
+        aux_data = ()  # static values
+        return (children, aux_data)
+
+    _children_labels = ("gamma",)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        (obj.gamma,) = children
+        return obj
+
+
+class FromCallable(InstrumentFunction):
+    def __init__(self, function: callable):
+        """
+        Create an :py:class`~.InstrumentFunction` from a callable.
+        """
+        self.function = jax.tree_util.Partial(function)
+
+    def __call__(self, omega):
+        return self.function(omega)
+
+    def _tree_flatten(self):
+        children = ()
+        aux_data = (self.function,)  # static values
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        (obj.function,) = aux_data
+        return obj
+
+
+class FromArray(InstrumentFunction):
+    def __init__(self, x, ints):
+        """
+        Set instrument function from an array input.
+        The intensities ``I`` have to have the same length as the energy shift
+        ``x``.
+
+        Parameters
+        ----------
+        x: Quantity
+            :math:`\\omega` or energy shift. Should be given in units of 1/time
+            or in energy units.
+        ints: jnp.ndarray | float | Quantity
+            Intensity values of Instrument function.
+        """
+        if x.check("[energy]"):
+            x = x / (1 * ureg.hbar)
+        self.omega = x
+        w = x.m_as(ureg.electron_volt / ureg.hbar)
+        if isinstance(ints, Quantity):
+            ints = ints.to_base_units().magnitude
+
+        # Assert normalization
+        ints /= jnp.trapezoid(y=ints, x=w)
+        self.ints = ints * (1 * ureg.hbar / ureg.electron_volt)
+
+    @jax.jit
+    def __call__(self, omega):
+        omega_mag = omega.m_as(ureg.electron_volt / ureg.hbar)
+        x_mag = self.omega.m_as(ureg.electron_volt / ureg.hbar)
+        ints_mag = self.ints.m_as(ureg.hbar / ureg.electron_volt)
+        ints_func = jnp.interp(omega_mag, x_mag, ints_mag, left=0, right=0)
+        return ints_func * (1 * ureg.hbar / ureg.electron_volt)
+
+    _children_labels = ("omega", "intensity")
+
+    def _tree_flatten(self):
+        children = (self.omega, self.ints)
+        aux_data = ()  # static values
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        (obj.omega, obj.ints) = children
+        return obj
 
 
 @jax.jit
@@ -87,7 +320,7 @@ def instrument_supergaussian(
     norm = jax.scipy.integrate.trapezoid(_y, _x)
 
     return jnp.exp(
-        -(0.5 * x**2 / sigma**2).m_as(ureg.dimensionless) ** power
+        -((0.5 * x**2 / sigma**2).m_as(ureg.dimensionless) ** power)
     ) / (norm * sigma)
 
 
@@ -139,65 +372,9 @@ def instrument_from_file(
         frequency shift), and returns the weight of this shift. The function is
         normalized to one.
     """
-
     data = onp.genfromtxt(filename, delimiter=",", skip_header=0)
 
     x, ints = data[:, 0], data[:, 1]
     x *= xunit
 
-    if x.check("[energy]"):
-        x = x / (1 * ureg.hbar)
-
-    w = x.m_as(ureg.electron_volt / ureg.hbar)
-
-    ints /= jnp.trapezoid(y=ints, x=w)
-
-    def inst_func_fxrts(_w):
-        w_mag = _w.m_as(ureg.electron_volt / ureg.hbar)
-        ints_func = jnp.interp(w_mag, w, ints, left=0, right=0)
-        return ints_func * (1 * ureg.hbar / ureg.electron_volt)
-
-    return jax.tree_util.Partial(inst_func_fxrts)
-
-
-def instrument_from_array(
-    x: Quantity, ints: jnp.ndarray | Quantity
-) -> Callable[[Quantity], Quantity]:
-    """
-    Set instrument function from an array input.
-    The intensities have to have the same length as the energy shift.
-
-    Parameters
-    ----------
-    x: Quantity
-        :math:`\\omega` or energy shift. Should be given in units of 1/time or
-        in energy units.
-    ints: jnp.ndarray | float | Quantity
-        Intensity values of Instrument function.
-
-    Returns
-    -------
-    Callable
-        The instrument function, which takes one singular argument (the
-        frequency shift), and returns the weight of this shift. The function is
-        normalized to one.
-    """
-    # Handle units
-
-    # if x is given in energy units, convert to 1/time
-    if x.check("[energy]"):
-        x = x / (1 * ureg.hbar)
-    w = x.m_as(ureg.electron_volt / ureg.hbar)
-    if isinstance(ints, Quantity):
-        ints = ints.to_base_units().magnitude
-
-    # Assert normalization
-    ints /= jnp.trapezoid(y=ints, x=w)
-
-    @jax.jit
-    def inst_func_fxrts(_w):
-        w_mag = _w.m_as(ureg.electron_volt / ureg.hbar)
-        ints_func = jnp.interp(w_mag, w, ints, left=0, right=0)
-        return ints_func * (1 * ureg.hbar / ureg.electron_volt)
-
-    return jax.tree_util.Partial(inst_func_fxrts)
+    return FromArray(x, ints)

--- a/src/jaxrts/saving.py
+++ b/src/jaxrts/saving.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 import jpu.numpy as jnpu
 import numpy as onp
 
-from .collections import get_all_models_list
+from .collections import get_all_models_list, get_all_instrument_functions
 from .elements import Element
 from .helpers import partialclass
 from .hnc_potentials import HNCPotential
@@ -30,6 +30,7 @@ from .models import Model
 from .plasmastate import PlasmaState
 from .setup import Setup
 from .units import Quantity
+from .instrument_function import InstrumentFunction
 
 
 def _flatten_obj(obj):
@@ -110,6 +111,11 @@ class JaXRTSEncoder(json.JSONEncoder):
                 "_type": "Model",
                 "value": (obj.__name__, _flatten_obj(obj)),
             }
+        elif isinstance(obj, InstrumentFunction):
+            return {
+                "_type": "InstrumentFunction",
+                "value": (obj.__class__.__name__, _flatten_obj(obj)),
+            }
         elif isinstance(obj, Element):
             return {
                 "_type": "Element",
@@ -187,6 +193,13 @@ class JaXRTSDecoder(json.JSONDecoder):
         model_dict.update(self.additional_mappings)
         return model_dict
 
+    @property
+    def instrument_functions(self) -> dict:
+        ifunc_list = get_all_instrument_functions()
+        ifunc_dict = {ifnc.__name__: ifnc for ifnc in ifunc_list}
+        ifunc_dict.update(self.additional_mappings)
+        return ifunc_dict
+
     def object_hook(self, obj):
         if "_type" not in obj:
             return obj
@@ -207,6 +220,15 @@ class JaXRTSDecoder(json.JSONDecoder):
 
             model = self.models[name]
             new = object.__new__(model)
+
+            children, aux_data = _parse_tree_save(new, *tree)
+            new = new._tree_unflatten(aux_data, children)
+            return new
+        elif _type == "InstrumentFunction":
+            name, tree = val
+
+            inst_fnc = self.instrument_functions[name]
+            new = object.__new__(inst_fnc)
 
             children, aux_data = _parse_tree_save(new, *tree)
             new = new._tree_unflatten(aux_data, children)

--- a/src/jaxrts/saving.py
+++ b/src/jaxrts/saving.py
@@ -14,6 +14,7 @@ which was an issue when pickeling a PlasmaState.
 """
 
 import base64
+import inspect
 import json
 
 import dill as pickle
@@ -140,6 +141,16 @@ class JaXRTSEncoder(json.JSONEncoder):
                 "_type": "jaxPartial",
                 "value": base64.b64encode(pickle.dumps(obj)).decode("utf-8"),
             }
+        elif inspect.isfunction(obj):
+            return {
+                "_type": "function",
+                "value": base64.b64encode(pickle.dumps(obj)).decode("utf-8"),
+            }
+        elif isinstance(obj, jax.tree_util.PyTreeDef):
+            return {
+                "_type": "jaxPyTreeDef",
+                "value": base64.b64encode(pickle.dumps(obj)).decode("utf-8"),
+            }
         return super().default(obj)
 
 
@@ -206,6 +217,10 @@ class JaXRTSDecoder(json.JSONDecoder):
         _type = obj["_type"]
         val = obj["value"]
         if _type == "jaxPartial":
+            return pickle.loads(base64.b64decode(val))
+        if _type == "jaxPyTreeDef":
+            return pickle.loads(base64.b64decode(val))
+        if _type == "function":
             return pickle.loads(base64.b64decode(val))
         if _type == "ndArray":
             return onp.array(val)

--- a/src/jaxrts/setup.py
+++ b/src/jaxrts/setup.py
@@ -11,6 +11,7 @@ from jpu import numpy as jnpu
 
 from .plasma_physics import plasma_frequency
 from .units import Quantity, ureg
+from .instrument_function import InstrumentFunction, FromCallable
 
 
 class Setup:
@@ -25,10 +26,13 @@ class Setup:
         scattering_angle: Quantity,
         energy: Quantity,
         measured_energy: Quantity,
-        instrument: Callable,
+        instrument: Callable | InstrumentFunction,
         correct_k_dispersion: bool = True,
         frc_exponent: float = 0.0,
     ):
+
+        if not isinstance(instrument, InstrumentFunction):
+            instrument = FromCallable(instrument)
 
         #: The scattering angle of the experiment
         self.scattering_angle: Quantity = scattering_angle
@@ -38,10 +42,11 @@ class Setup:
         #: The energies at which the scattering is recorded. This is an array
         #: of absolute energies and not an energy shift.
         self.measured_energy: Quantity = measured_energy
-        #: A callable function over energy shifts that gives the total
-        #: instrument spread. The curve should be normed so that the integral
-        #: from `-inf` to `inf` should be one.
-        self.instrument: Callable = jax.tree_util.Partial(instrument)
+        #: A :py:class:jaxrts.instrument_function.InstrumentFunction`,
+        #: basically a callable function over energy shifts that gives the
+        #: total instrument spread. The curve should be normed so that the
+        #: integral from `-inf` to `inf` should be one.
+        self.instrument: InstrumentFunction = instrument
         #: In an experiment, the value of k is dependent on the measured energy
         #: at this position on the detector. When including this effect, the
         #: returned spectrum will, however, violate detailed balance. It might
@@ -79,7 +84,7 @@ class Setup:
 
     def __repr__(self) -> str:
         E = f"{self.energy.m_as(ureg.electron_volt):.1f}"
-        k = f"{self.k.m_as(1/ureg.angstrom):.3f}"
+        k = f"{self.k.m_as(1 / ureg.angstrom):.3f}"
         theta = f"{self.scattering_angle.m_as(ureg.degree):1f}"
         out = f"Setup probing with {E} eV at {theta} deg (k = {k}/angstrom)."
         if self.frc_exponent > 0:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -3,8 +3,6 @@ These tests investigate that certain properties of a generated spectrum hold
 true.
 """
 
-from functools import partial
-
 import pytest
 from jax import numpy as jnp
 from jpu import numpy as jnpu
@@ -26,10 +24,7 @@ class TestITCFInstance:
         energy=ureg("6900 eV"),
         measured_energy=ureg("6900 eV")
         + jnp.linspace(-120, 120, 1000) * ureg.electron_volt,
-        instrument=partial(
-            jaxrts.instrument_function.instrument_gaussian,
-            sigma=ureg("1.0eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-        ),
+        instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("1.0eV")),
     )
 
     test_state["ionic scattering"] = jaxrts.models.OnePotentialHNCIonFeat()
@@ -83,10 +78,7 @@ class TestSSFInstance:
         energy=ureg("70 keV"),
         measured_energy=ureg("70 keV")
         + jnp.linspace(-15, 15, 6000) * ureg.kiloelectron_volt,
-        instrument=partial(
-            jaxrts.instrument_function.instrument_gaussian,
-            sigma=ureg("50eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-        ),
+        instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("50.0eV")),
     )
     test_setup.correct_k_dispersion = False
 
@@ -143,10 +135,7 @@ class TestFsumRuleInstance:
         energy=ureg("7.5 keV"),
         measured_energy=ureg("7.5 keV")
         + jnp.linspace(-2, 2, 5000) * ureg.kiloelectron_volt,
-        instrument=partial(
-            jaxrts.instrument_function.instrument_gaussian,
-            sigma=ureg("40eV") / ureg.hbar / (2 * jnp.sqrt(2 * jnp.log(2))),
-        ),
+        instrument=jaxrts.instrument_function.Gaussian(fwhm=ureg("40.0eV")),
     )
 
     test_state["ionic scattering"] = jaxrts.models.OnePotentialHNCIonFeat()

--- a/tests/test_jax_cache.py
+++ b/tests/test_jax_cache.py
@@ -1,0 +1,160 @@
+"""
+Tests checking whether the JIT cache grows (i.e. XLA recompiles) at different
+operations.
+"""
+
+from functools import partial
+
+import jax
+import pytest
+from jax import numpy as jnp
+
+import jaxrts
+
+ureg = jaxrts.ureg
+
+_PROBE_FN = jaxrts.PlasmaState.probe
+
+
+def _cache_size() -> int:
+    """
+    Number of distinct compiled versions cached for
+    :py:func:`jaxts.plasmastate.PlasmaState.probe`.
+    """
+    return _PROBE_FN._cache_size()
+
+
+@pytest.fixture(autouse=True)
+def _clean_jit_cache():
+    """
+    Ensure every test starts (and leaves) probe's jit cache empty.
+
+    Without this, cache growth from one test would leak into the next
+    and make the assertions order-dependent.
+    """
+    _PROBE_FN.clear_cache()
+    yield
+    _PROBE_FN.clear_cache()
+
+
+def make_state(Z_free=2.0) -> jaxrts.PlasmaState:
+    state = jaxrts.PlasmaState(
+        ions=[jaxrts.Element("Be")],
+        Z_free=jnp.array([Z_free]),
+        mass_density=jnp.array([1]) * ureg.gram / ureg.centimeter**3,
+        T_e=2 * ureg.electron_volt / ureg.k_B,
+    )
+    state["ionic scattering"] = jaxrts.models.Neglect()
+    state["free-free scattering"] = jaxrts.models.RPA_DandreaFit()
+    state["bound-free scattering"] = jaxrts.models.SchumacherImpulse()
+    state["free-bound scattering"] = jaxrts.models.DetailedBalance()
+    return state
+
+
+def make_setup(
+    angle=ureg("60deg"),
+    instrument=jaxrts.instrument_function.Gaussian(ureg("5eV")),
+) -> jaxrts.Setup:
+    return jaxrts.Setup(
+        scattering_angle=angle,
+        energy=ureg("4700 eV"),
+        measured_energy=ureg("4700 eV")
+        + jnp.linspace(-100, 40, 50) * ureg.electron_volt,
+        instrument=instrument,
+    )
+
+
+def run_probe(state: jaxrts.PlasmaState, setup: jaxrts.Setup):
+    result = state.probe(setup)
+    jax.block_until_ready(result)
+    return result
+
+
+class TestProbeJitCacheGrowth:
+    def test_new_state_and_setup_does_not_recompile(self):
+        """
+        Creating new, identical objects does not recompile.
+        """
+
+        def f(x):
+            return 1 / x
+
+        state = make_state()
+        setup = make_setup(instrument=f)
+
+        run_probe(state, setup)
+        size_after_first = _cache_size()
+
+        state = make_state()
+        setup = make_setup(instrument=f)
+
+        run_probe(state, setup)
+        size_after_second = _cache_size()
+
+        assert size_after_first == 1
+        assert size_after_second == size_after_first
+
+    def test_new_instrument_function_recompiles(self):
+        """
+        When defining a new instrument function we have to recompile, even if
+        the functions definition is the same.
+        """
+        state = make_state()
+        setup = make_setup(instrument=lambda x: 1 / x)
+
+        run_probe(state, setup)
+        size_after_first = _cache_size()
+
+        state = make_state()
+        setup = make_setup(instrument=lambda x: 1 / x)
+
+        run_probe(state, setup)
+        size_after_second = _cache_size()
+
+        assert size_after_first == 1
+        assert size_after_second == size_after_first + 1
+
+    def test_partial_as_instrument_function_does_not_recompile(self):
+        """
+        The construction of :py:class:`jaxrts.instrument.FromCallable` allows
+        to trace trough partial objects.
+        """
+
+        def f(x, a):
+            return a / x
+
+        state = make_state()
+        setup = make_setup(instrument=partial(f, a=1))
+
+        run_probe(state, setup)
+        size_after_first = _cache_size()
+
+        state = make_state()
+        setup = make_setup(instrument=partial(f, a=2))
+
+        run_probe(state, setup)
+        size_after_second = _cache_size()
+
+        assert size_after_first == 1
+        assert size_after_second == size_after_first
+
+    def test_traced_values_dont_recompile(self):
+        """
+        Creating new objects where only traced values are changed will not
+        trigger a recompile.
+        """
+
+        state = make_state(Z_free=1.0)
+        setup = make_setup(angle=ureg("40deg"))
+
+        run_probe(state, setup)
+        size_after_first = _cache_size()
+
+        state = make_state(Z_free=1.4)
+        setup = make_setup(angle=ureg("80deg"))
+
+        run_probe(state, setup)
+        size_after_second = _cache_size()
+
+        assert size_after_first == 1
+        assert size_after_second == size_after_first

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -68,17 +68,13 @@ def test_instrumentfunction_from_array() -> None:
     intensities = psf(w) * 42
 
     # with units on intensities
-    array_psf_1 = jaxrts.instrument_function.instrument_from_array(
-        w, intensities
-    )
+    array_psf_1 = jaxrts.instrument_function.FromArray(w, intensities)
     # without units on intensities
-    array_psf_2 = jaxrts.instrument_function.instrument_from_array(
+    array_psf_2 = jaxrts.instrument_function.FromArray(
         w, intensities.m_as(ureg.picosecond)
     )
     # define the PSF over the energy and not frequencies
-    array_psf_3 = jaxrts.instrument_function.instrument_from_array(
-        E, intensities
-    )
+    array_psf_3 = jaxrts.instrument_function.FromArray(E, intensities)
 
     assert jnp.all(jnpu.isclose(psf(w), array_psf_1(w)))
     assert jnp.all(jnpu.isclose(psf(w), array_psf_2(w)))


### PR DESCRIPTION
I've noted that creating the standard setup (e.g.,https://github.com/JaXRTS/jaxrts/blob/510dcc8b4764beeed94efc888d333c5c61721ef7/doc/examples/plot_getting_started.py#L36-L45) twice and running `probe` after, each time, we were always recompiling as the instrument function function given to the `Setup` was a new object.

This pr fixes the behavior, by doing two things:

1. Instead of having the instrument function passed to the `Setup` being a callable, use a new class: `InstrumentFunction`. This allows to define instrument functions that can be saved and traced transparently, and the interface is nicer, I think. Instead of `functools.partial(jaxrts.instrument_function.instrument_gaussian, sigma=ureg("5.0eV"))` you can now write `jaxrts.instrument_function.Gaussian(sigma=ureg("5.0eV"))`.
2. To guarantee backwards compatibility, automatically create a `FromCallable` `InstrumentFunction` when the `instrument` argument is not an `InstrumentFunction`, itself. Here, we unfold a potential `partial`, so that the arguments and keyword arguments can be traced, transparently. This fix alone would suffice to tackle my initial reason to write this PR, but the simpler interface, is -- I think -- a win and we should alongside these changes.

I've provided a test script that verifies that the jit cache is not growing when re-generating Setup and PlasmaState, but not changing static values.