### PR TITLE
fix: stabilize ITCFT against shifting of the energy grid

### DIFF
--- a/src/jaxrts/analysis.py
+++ b/src/jaxrts/analysis.py
@@ -36,7 +36,26 @@ def twoSidedLaplace(
 
     # Sort energy and intensity for the integration
     inten_sorted = intensity[jnpu.argsort(E_shift)]
-    E_sorted = E_shift[jnpu.argsort(E_shift)]
+    _E_sorted = E_shift[jnpu.argsort(E_shift)]
+
+    # Assert that values just around E_min and E_max are in E_sorted, so that
+    # the integral is less error-prone to not being symmetric around 0.
+
+    small = 1e-8
+    E_sorted = (
+        jnp.array(
+            [
+                *_E_sorted.m_as(ureg.electron_volt),
+                E_min.m_as(ureg.electron_volt) - small,
+                E_min.m_as(ureg.electron_volt) + small,
+                E_max.m_as(ureg.electron_volt) + small,
+                E_max.m_as(ureg.electron_volt) - small,
+            ]
+        )
+        * ureg.electron_volt
+    )
+    E_sorted = jnpu.sort(E_sorted)
+    inten_sorted = jnpu.interp(E_sorted, _E_sorted, inten_sorted)
 
     # Integrate in energy space (this way, the integral is numerically more
     # stable compared to omega_space. This results in a dimensionless result,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -4,6 +4,7 @@ true.
 """
 
 from functools import partial
+from copy import deepcopy
 
 import pytest
 from jax import numpy as jnp
@@ -37,13 +38,13 @@ class TestITCFInstance:
     test_state["bound-free scattering"] = jaxrts.models.SchumacherImpulse()
     test_state["free-bound scattering"] = jaxrts.models.DetailedBalance()
 
-    def get_T(self, raw):
+    def get_T(self, raw=False, x=ureg("100eV")):
         S_ee = self.test_state.probe(self.test_setup)
         T = jaxrts.analysis.ITCFT(
             S_ee,
             ureg("60/keV"),
             self.test_setup,
-            ureg("100eV"),
+            x,
             raw=raw,
         )
         return T
@@ -59,6 +60,22 @@ class TestITCFInstance:
         assert jnpu.absolute(
             self.get_T(raw=False) - self.test_state.T_e
         ) < ureg("2e3K")
+
+    def test_ITCFT_stable_against_moving_energy_grid(self):
+        # We require small values for x. For big x, convergence should always
+        # reach the correct value
+        _x = jnp.array([10, 15, 20]) * ureg.electron_volt
+        self.test_setup.correct_k_dispersion = False
+        T1 = (
+            jnp.array([self.get_T(x=x).m_as(ureg.kelvin) for x in _x])
+            * ureg.kelvin
+        )
+        self.test_setup.measured_energy += 0.1 * ureg.electron_volt
+        T2 = (
+            jnp.array([self.get_T(x=x).m_as(ureg.kelvin) for x in _x])
+            * ureg.kelvin
+        )
+        assert jnpu.max(jnpu.absolute(T1 - T2)) < ureg("1e3K")
 
     @pytest.mark.xfail(
         reason="The k-dispersion should violate detailed balance"


### PR DESCRIPTION
In the old implementation, setting the integration boundaries of the Laplace transform (as it is done, e.g., when checking $x$ for convergence when performing the ITCFT) was just masking the `Setup` energy grid. This resulted in a noisy temperature over $x$ curve when the energy grid was not centered around 0. Instead, we now interpolate values left and right of the edge before the integration. This way also non-symmetric energy shifts are stable (see pictures).

before: 
<img width="330" height="242" alt="before" src="https://github.com/user-attachments/assets/da3a1a7a-d417-455d-82af-88784514666f" />

after:
<img width="330" height="242" alt="after" src="https://github.com/user-attachments/assets/744470ae-0629-4d50-b334-4eaa87aa60c4" />


A test is added to the test-suite